### PR TITLE
LINK-684 | Cancelling enrolment

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,5 +1,6 @@
 {
   "appName": "Linked Registrations",
+  "cancel": "Undo",
   "dropdownSelect": {
     "accessibility": {
       "noResults": "No options",
@@ -66,5 +67,6 @@
       "required": "This field is required",
       "zip": "This field must be a valid postcode"
     }
-  }
+  },
+  "warning": "Warning!"
 }

--- a/public/locales/en/enrolment.json
+++ b/public/locales/en/enrolment.json
@@ -1,5 +1,15 @@
 {
+  "buttonCancel": "Cancel registration",
   "buttonSend": "Submit registration",
+  "cancelEnrolmentModal": {
+    "buttonCancel": "Cancel registration",
+    "text": "This operation cannot be undone.",
+    "title": "Are you sure you want to cancel the registration?"
+  },
+  "cancelledPage": {
+    "text": "You have canceled your registration for our event {{name}}.",
+    "title": "Your registration has been canceled"
+  },
   "completedPage": {
     "text": "You have signed up to our event {{name}} - welcome!",
     "title": "Thank you for signing up!"

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -1,5 +1,6 @@
 {
   "appName": "Linked Registrations",
+  "cancel": "Peruuta",
   "dropdownSelect": {
     "accessibility": {
       "noResults": "Ei vaihtoehtoja",
@@ -65,6 +66,7 @@
       "phone": "Tämän kentän on oltava kelvollinen puhelinnumero",
       "required": "Tämä kenttä on pakollinen",
       "zip": "Tämän kentän on oltava kelvollinen postinumero"
-    }
+    },
+    "warning": "Varoitus!"
   }
 }

--- a/public/locales/fi/enrolment.json
+++ b/public/locales/fi/enrolment.json
@@ -1,5 +1,15 @@
 {
+  "buttonCancel": "Peruuta ilmoittautuminen",
   "buttonSend": "Lähetä ilmoittautuminen",
+  "cancelEnrolmentModal": {
+    "buttonCancel": "Peruuta ilmoittautuminen",
+    "text": "Tätä toimintoa ei voi perua.",
+    "title": "Haluatko varmasti poistaa ilmoittautumisen?"
+  },
+  "cancelledPage": {
+    "text": "Olet perunut ilmoittautumisesi tapahtumaamme {{name}}.",
+    "title": "Ilmoittautumisesi on peruttu"
+  },
   "completedPage": {
     "text": "Olet ilmoittanut tapahtumaamme {{name}} – sydämellisesti tervetuloa!",
     "title": "Kiitos ilmoittautumisestasi!"

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -1,5 +1,6 @@
 {
   "appName": "Linked Registrations",
+  "cancel": "Ångra",
   "dropdownSelect": {
     "accessibility": {
       "noResults": "Inga alternativ",
@@ -66,5 +67,6 @@
       "required": "Detta fält krävs",
       "zip": "Detta fält måste vara en giltig postnummer"
     }
-  }
+  },
+  "warning": "Varning!"
 }

--- a/public/locales/sv/enrolment.json
+++ b/public/locales/sv/enrolment.json
@@ -1,5 +1,15 @@
 {
+  "buttonCancel": "Avbryt registreringen",
   "buttonSend": "Skicka in registrering",
+  "cancelEnrolmentModal": {
+    "buttonCancel": "Avbryt registreringen",
+    "text": "Denna operation kan inte ångras.",
+    "title": "Är du säker på att du vill avbryta registreringen?"
+  },
+  "cancelledPage": {
+    "text": "Du har avbokat din anmälan till vårt evenemang {{name}}.",
+    "title": "Din registrering har avbrutits"
+  },
   "completedPage": {
     "text": "Du har registrerat dig för vårt evenemang {{name}} - välkommen!",
     "title": "Tack för din registrering!"

--- a/src/common/components/cancelledTempale/CancelledTemplate.tsx
+++ b/src/common/components/cancelledTempale/CancelledTemplate.tsx
@@ -1,0 +1,23 @@
+import { IconCross } from 'hds-react';
+import React from 'react';
+
+import Container from '../../../domain/app/layout/container/Container';
+import styles from './cancelledTemplate.module.scss';
+
+interface Props {
+  title: string;
+}
+
+const CancelledTemplate: React.FC<Props> = ({ children, title }) => {
+  return (
+    <Container contentWrapperClassName={styles.cancelledTemplate}>
+      <div className={styles.content}>
+        <IconCross className={styles.icon} aria-hidden={true} />
+        <h1>{title}</h1>
+        {children}
+      </div>
+    </Container>
+  );
+};
+
+export default CancelledTemplate;

--- a/src/common/components/cancelledTempale/cancelledTemplate.module.scss
+++ b/src/common/components/cancelledTempale/cancelledTemplate.module.scss
@@ -1,0 +1,43 @@
+@import '../../../styles/breakpoints.scss';
+@import '../../../styles/widths.scss';
+
+.cancelledTemplate {
+  --cancelled-template-icon-color: var(--color-error);
+  --cancelled-template-icon-size: 112px;
+  --cancelled-template-title-color: var(--color-black);
+
+  display: grid;
+  grid-gap: var(--spacing-m);
+  padding-top: var(--spacing-5-xl);
+
+  .content {
+    text-align: center;
+    margin: 0 auto;
+
+    h1 {
+      font-size: var(--fontsize-heading-l);
+      color: var(--success-template-title-color);
+      margin: 0;
+      line-height: var(--lineheight-m);
+    }
+
+    p {
+      font-size: var(--fontsize-body-l);
+      line-height: var(--lineheight-l);
+      margin: var(--spacing-2-xs) auto;
+      min-height: var(--spacing-m);
+
+      &:first-of-type {
+        margin: var(--spacing-m) auto var(--spacing-2-xs);
+      }
+
+      @include max-width-column(4);
+    }
+  }
+
+  .icon {
+    color: var(--cancelled-template-icon-color);
+    height: var(--cancelled-template-icon-size);
+    width: var(--cancelled-template-icon-size);
+  }
+}

--- a/src/common/components/formFields/DateInputField.tsx
+++ b/src/common/components/formFields/DateInputField.tsx
@@ -47,6 +47,7 @@ const DateInputField: React.FC<Props> = ({
       invalid={Boolean(errorText)}
       onBlur={handleBlur}
       onChange={handleChange}
+      value={value}
     />
   );
 };

--- a/src/domain/app/routes/constants.ts
+++ b/src/domain/app/routes/constants.ts
@@ -1,5 +1,6 @@
 export enum ROUTES {
   CREATE_ENROLMENT = '/registration/[registrationId]/enrolment/create',
   ENROLMENT_COMPLETED = '/registration/[registrationId]/enrolment/[enrolmentId]/completed/[accessCode]',
+  ENROLMENT_CANCELLED = '/registration/[registrationId]/enrolment/cancelled',
   HOME = '/',
 }

--- a/src/domain/enrolment/EditEnrolmentPage.tsx
+++ b/src/domain/enrolment/EditEnrolmentPage.tsx
@@ -10,28 +10,39 @@ import { Event } from '../event/types';
 import NotFound from '../notFound/NotFound';
 import { useRegistrationQuery } from '../registration/query';
 import { Registration } from '../registration/types';
-import CreateEnrolmentPageMeta from './createEnrolmentPageMeta/CreateEnrolmentPageMeta';
+import { enrolment } from './__mocks__/enrolment';
+import EditEnrolmentPageMeta from './editEnrolmentPageMeta/EditEnrolmentPageMeta';
 import EnrolmentForm from './enrolmentForm/EnrolmentForm';
 import styles from './enrolmentPage.module.scss';
 import EventInfo from './eventInfo/EventInfo';
-import { getEnrolmentDefaultInitialValues } from './utils';
+import { Enrolment } from './types';
+import { getEnrolmentInitialValues } from './utils';
 
 type Props = {
+  cancellationCode: string;
+  enrolment: Enrolment;
   event: Event;
   registration: Registration;
 };
 
-const CreateEnrolmentPage: React.FC<Props> = ({ event, registration }) => {
-  const initialValues = getEnrolmentDefaultInitialValues(registration);
+const EditEnrolmentPage: React.FC<Props> = ({
+  cancellationCode,
+  enrolment,
+  event,
+  registration,
+}) => {
+  const initialValues = getEnrolmentInitialValues(enrolment, registration);
   return (
     <MainContent>
-      <CreateEnrolmentPageMeta event={event} />
+      <EditEnrolmentPageMeta event={event} />
       <Container withOffset>
         <div className={styles.formContainer}>
           <EventInfo event={event} />
           <div className={styles.divider} />
           <EnrolmentForm
+            cancellationCode={cancellationCode}
             initialValues={initialValues}
+            readOnly={true}
             registration={registration}
           />
         </div>
@@ -40,15 +51,12 @@ const CreateEnrolmentPage: React.FC<Props> = ({ event, registration }) => {
   );
 };
 
-const CreateEnrolmentPageWrapper: React.FC = () => {
-  const router = useRouter();
-  const { query } = router;
+const EditEnrolmentPageWrapper: React.FC = () => {
+  const { query } = useRouter();
 
   const { data: registration, isLoading: isLoadingRegistration } =
     useRegistrationQuery(
-      {
-        id: query.registrationId as string,
-      },
+      { id: query.registrationId as string },
       { enabled: !!query.registrationId }
     );
 
@@ -63,7 +71,12 @@ const CreateEnrolmentPageWrapper: React.FC = () => {
   return (
     <LoadingSpinner isLoading={isLoadingRegistration || isLoadingEvent}>
       {registration && event ? (
-        <CreateEnrolmentPage event={event} registration={registration} />
+        <EditEnrolmentPage
+          cancellationCode={query.accessCode as string}
+          enrolment={enrolment}
+          event={event}
+          registration={registration}
+        />
       ) : (
         <NotFound />
       )}
@@ -71,4 +84,4 @@ const CreateEnrolmentPageWrapper: React.FC = () => {
   );
 };
 
-export default CreateEnrolmentPageWrapper;
+export default EditEnrolmentPageWrapper;

--- a/src/domain/enrolment/EnrolmentCancelledPage.tsx
+++ b/src/domain/enrolment/EnrolmentCancelledPage.tsx
@@ -3,8 +3,8 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import React from 'react';
 
+import CancelledTemplate from '../../common/components/cancelledTempale/CancelledTemplate';
 import LoadingSpinner from '../../common/components/loadingSpinner/LoadingSpinner';
-import SuccessTemplate from '../../common/components/successTemplate/SuccessTemplate';
 import useLocale from '../../hooks/useLocale';
 import MainContent from '../app/layout/mainContent/MainContent';
 import { EVENT_INCLUDES } from '../event/constants';
@@ -13,39 +13,30 @@ import { Event } from '../event/types';
 import { getEventFields } from '../event/utils';
 import NotFound from '../notFound/NotFound';
 import { useRegistrationQuery } from '../registration/query';
-import { Registration } from '../registration/types';
-import { getRegistrationFields } from '../registration/utils';
-import ConfirmationMessage from './confirmationMessage/ConfirmationMessage';
 
 type Props = {
   event: Event;
-  registration: Registration;
 };
 
-const EnrolmentCompletedPage: React.FC<Props> = ({ event, registration }) => {
+const EnrolmentCompletedPage: React.FC<Props> = ({ event }) => {
   const { t } = useTranslation(['enrolment']);
   const locale = useLocale();
 
   const { name } = getEventFields(event, locale);
-  const { confirmationMessage } = getRegistrationFields(registration);
 
   return (
     <MainContent>
       <Head>
-        <title>{t('completedPage.title')}</title>
+        <title>{t('cancelledPage.title')}</title>
       </Head>
-      <SuccessTemplate title={t('completedPage.title')}>
-        {confirmationMessage ? (
-          <ConfirmationMessage registration={registration} />
-        ) : (
-          <p>{t('completedPage.text', { name })}</p>
-        )}
-      </SuccessTemplate>
+      <CancelledTemplate title={t('cancelledPage.title')}>
+        <p>{t('cancelledPage.text', { name })}</p>
+      </CancelledTemplate>
     </MainContent>
   );
 };
 
-const EnrolmentCompletedPageWrapper: React.FC = () => {
+const EnrolmentCancelledPageWrapper: React.FC = () => {
   const { query } = useRouter();
 
   const { data: registration, isLoading: isLoadingRegistration } =
@@ -61,13 +52,9 @@ const EnrolmentCompletedPageWrapper: React.FC = () => {
 
   return (
     <LoadingSpinner isLoading={isLoadingRegistration || isLoadingEvent}>
-      {registration && event ? (
-        <EnrolmentCompletedPage event={event} registration={registration} />
-      ) : (
-        <NotFound />
-      )}
+      {event ? <EnrolmentCompletedPage event={event} /> : <NotFound />}
     </LoadingSpinner>
   );
 };
 
-export default EnrolmentCompletedPageWrapper;
+export default EnrolmentCancelledPageWrapper;

--- a/src/domain/enrolment/__mocks__/enrolment.ts
+++ b/src/domain/enrolment/__mocks__/enrolment.ts
@@ -1,0 +1,5 @@
+import { fakeEnrolment } from '../../../utils/mockDataUtils';
+
+const enrolment = fakeEnrolment();
+
+export { enrolment };

--- a/src/domain/enrolment/__tests__/EditEnrolmentPage.test.tsx
+++ b/src/domain/enrolment/__tests__/EditEnrolmentPage.test.tsx
@@ -1,0 +1,227 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { axe } from 'jest-axe';
+import { rest } from 'msw';
+import mockRouter from 'next-router-mock';
+import singletonRouter from 'next/router';
+import React from 'react';
+
+import {
+  act,
+  actWait,
+  configure,
+  render,
+  screen,
+  setQueryMocks,
+  userEvent,
+  waitFor,
+  within,
+} from '../../../utils/testUtils';
+import { event } from '../../event/__mocks__/event';
+import { TEST_EVENT_ID } from '../../event/constants';
+import { languagesResponse } from '../../language/__mocks__/languages';
+import { place } from '../../place/__mocks__/place';
+import { TEST_PLACE_ID } from '../../place/constants';
+import { registration } from '../../registration/__mocks__/registration';
+import { TEST_REGISTRATION_ID } from '../../registration/constants';
+import EditEnrolmentPage from '../EditEnrolmentPage';
+
+configure({ defaultHidden: true });
+
+jest.mock('next/dist/client/router', () => require('next-router-mock'));
+
+const findElement = (key: 'nameInput') => {
+  switch (key) {
+    case 'nameInput':
+      return screen.findByRole('textbox', { name: /nimi/i });
+  }
+};
+
+const getElement = (
+  key:
+    | 'cancelButton'
+    | 'cityInput'
+    | 'dateOfBirthInput'
+    | 'emailCheckbox'
+    | 'emailInput'
+    | 'nameInput'
+    | 'nativeLanguageButton'
+    | 'phoneCheckbox'
+    | 'phoneInput'
+    | 'serviceLanguageButton'
+    | 'streetAddressInput'
+    | 'zipInput'
+) => {
+  switch (key) {
+    case 'cancelButton':
+      return screen.getByRole('button', { name: /peruuta ilmoittautuminen/i });
+    case 'cityInput':
+      return screen.getByRole('textbox', { name: /kaupunki/i });
+    case 'dateOfBirthInput':
+      return screen.getByRole('textbox', { name: /syntymäaika/i });
+    case 'emailCheckbox':
+      return screen.getByRole('checkbox', { name: /sähköpostilla/i });
+    case 'emailInput':
+      return screen.getByRole('textbox', { name: /sähköpostiosoite/i });
+    case 'nameInput':
+      return screen.getByRole('textbox', { name: /nimi/i });
+    case 'nativeLanguageButton':
+      return screen.getByRole('button', { name: /äidinkieli/i });
+    case 'phoneCheckbox':
+      return screen.getByRole('checkbox', { name: /tekstiviestillä/i });
+    case 'phoneInput':
+      return screen.getByRole('textbox', { name: /puhelinnumero/i });
+    case 'serviceLanguageButton':
+      return screen.getByRole('button', { name: /asiointikieli/i });
+    case 'streetAddressInput':
+      return screen.getByRole('textbox', { name: /katuosoite/i });
+    case 'zipInput':
+      return screen.getByRole('textbox', { name: /postinumero/i });
+  }
+};
+
+const renderComponent = () => render(<EditEnrolmentPage />);
+
+test.skip('page is accessible', async () => {
+  const { container } = renderComponent();
+
+  await findElement('nameInput');
+  expect(await axe(container)).toHaveNoViolations();
+});
+
+const defaultMocks = [
+  rest.get(`*/event/${TEST_EVENT_ID}/`, (req, res, ctx) =>
+    res(ctx.status(200), ctx.json(event))
+  ),
+  rest.get(`*/place/${TEST_PLACE_ID}/`, (req, res, ctx) =>
+    res(ctx.status(200), ctx.json(place))
+  ),
+  rest.get('*/language/', (req, res, ctx) =>
+    res(ctx.status(200), ctx.json(languagesResponse))
+  ),
+  rest.get(`*/registration/${TEST_REGISTRATION_ID}/`, (req, res, ctx) =>
+    res(ctx.status(200), ctx.json(registration))
+  ),
+];
+
+test('should edit enrolment page field', async () => {
+  setQueryMocks(...defaultMocks);
+  singletonRouter.push({
+    pathname: 'registration/[registrationId]/enrolment/create',
+    query: { registrationId: TEST_REGISTRATION_ID },
+  });
+  renderComponent();
+
+  const nameInput = await findElement('nameInput');
+  const streetAddressInput = getElement('streetAddressInput');
+  const dateOfBirthInput = getElement('dateOfBirthInput');
+  const zipInput = getElement('zipInput');
+  const cityInput = getElement('cityInput');
+  const emailInput = getElement('emailInput');
+  const phoneInput = getElement('phoneInput');
+  const emailCheckbox = getElement('emailCheckbox');
+  const phoneCheckbox = getElement('phoneCheckbox');
+  const nativeLanguageButton = getElement('nativeLanguageButton');
+  const serviceLanguageButton = getElement('serviceLanguageButton');
+  getElement('cancelButton');
+
+  expect(nameInput.hasAttribute('readonly')).toBeTruthy();
+  expect(streetAddressInput.hasAttribute('readonly')).toBeTruthy();
+  expect(dateOfBirthInput.hasAttribute('readonly')).toBeTruthy();
+  expect(zipInput.hasAttribute('readonly')).toBeTruthy();
+  expect(cityInput.hasAttribute('readonly')).toBeTruthy();
+  expect(emailInput.hasAttribute('readonly')).toBeTruthy();
+  expect(phoneInput.hasAttribute('readonly')).toBeTruthy();
+  expect(emailCheckbox).toBeDisabled();
+  expect(phoneCheckbox).toBeDisabled();
+  expect(nativeLanguageButton).toBeDisabled();
+  expect(serviceLanguageButton).toBeDisabled();
+});
+
+test('should cancel enrolment', async () => {
+  setQueryMocks(
+    ...defaultMocks,
+    rest.delete(`*/signup/`, (req, res, ctx) =>
+      res(ctx.status(201), ctx.json(null))
+    )
+  );
+  singletonRouter.push({
+    pathname: 'registration/[registrationId]/enrolment/create',
+    query: { registrationId: TEST_REGISTRATION_ID },
+  });
+  renderComponent();
+
+  await findElement('nameInput');
+
+  const cancelButton = getElement('cancelButton');
+  act(() => userEvent.click(cancelButton));
+  const modal = await screen.findByRole('dialog', {
+    name: 'Haluatko varmasti poistaa ilmoittautumisen?',
+  });
+  const withinModal = within(modal);
+  const cancelEnrolmentButton = withinModal.getByRole('button', {
+    name: 'Peruuta ilmoittautuminen',
+  });
+  userEvent.click(cancelEnrolmentButton);
+
+  await waitFor(() =>
+    expect(mockRouter.asPath).toBe(
+      `/fi/registration/${TEST_REGISTRATION_ID}/enrolment/cancelled`
+    )
+  );
+});
+
+test('should show error message when cancelling enrolment fails', async () => {
+  setQueryMocks(
+    ...defaultMocks,
+    rest.delete(`*/signup/`, (req, res, ctx) =>
+      res(ctx.status(403), ctx.json({ detail: 'Malformed UUID.' }))
+    )
+  );
+  singletonRouter.push({
+    pathname: 'registration/[registrationId]/enrolment/create',
+    query: { registrationId: TEST_REGISTRATION_ID },
+  });
+  renderComponent();
+
+  await findElement('nameInput');
+
+  const cancelButton = getElement('cancelButton');
+  act(() => userEvent.click(cancelButton));
+  const modal = await screen.findByRole('dialog', {
+    name: 'Haluatko varmasti poistaa ilmoittautumisen?',
+  });
+  const withinModal = within(modal);
+  const cancelEnrolmentButton = withinModal.getByRole('button', {
+    name: 'Peruuta ilmoittautuminen',
+  });
+  userEvent.click(cancelEnrolmentButton);
+
+  await screen.findByRole(
+    'heading',
+    { name: /lomakkeella on seuraavat virheet/i },
+    { timeout: 10000 }
+  );
+});
+
+test('should show not found page if registration does not exist', async () => {
+  setQueryMocks(
+    rest.get(`*/registration/not-found/`, (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ errorMessage: 'Not found' }))
+    )
+  );
+
+  singletonRouter.push({
+    pathname: 'registration/[registrationId]/enrolment/create',
+    query: { registrationId: 'not-found' },
+  });
+  renderComponent();
+
+  await screen.findByRole('heading', {
+    name: 'Valitettavasti etsimääsi sivua ei löydy',
+  });
+
+  screen.getByText(
+    'Hakemaasi sivua ei löytynyt. Yritä myöhemmin uudelleen. Jos ongelma jatkuu, ota meihin yhteyttä.'
+  );
+});

--- a/src/domain/enrolment/__tests__/EnrolmentCancelledPage.test.tsx
+++ b/src/domain/enrolment/__tests__/EnrolmentCancelledPage.test.tsx
@@ -1,0 +1,36 @@
+import { rest } from 'msw';
+import React from 'react';
+
+import { fakeRegistration } from '../../../utils/mockDataUtils';
+import { render, screen, setQueryMocks } from '../../../utils/testUtils';
+import { event, eventOverrides } from '../../event/__mocks__/event';
+import { TEST_EVENT_ID } from '../../event/constants';
+import { TEST_REGISTRATION_ID } from '../../registration/constants';
+import EnrolmentCancelledPage from '../EnrolmentCancelledPage';
+
+const renderComponent = () =>
+  render(<EnrolmentCancelledPage />, {
+    query: { registrationId: TEST_REGISTRATION_ID },
+  });
+
+test('should show enrolment cancelled text', async () => {
+  const registration = fakeRegistration({
+    id: TEST_REGISTRATION_ID,
+    event: TEST_EVENT_ID,
+  });
+
+  setQueryMocks(
+    rest.get(`*/event/${TEST_EVENT_ID}/`, (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(event))
+    ),
+    rest.get(`*/registration/${TEST_REGISTRATION_ID}`, (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(registration))
+    )
+  );
+  renderComponent();
+
+  await screen.findByRole('heading', { name: 'Ilmoittautumisesi on peruttu' });
+  screen.getByText(
+    `Olet perunut ilmoittautumisesi tapahtumaamme ${eventOverrides.name.fi}.`
+  );
+});

--- a/src/domain/enrolment/__tests__/utils.test.ts
+++ b/src/domain/enrolment/__tests__/utils.test.ts
@@ -1,7 +1,4 @@
-import {
-  fakeRegistration,
-  fakeRegistrations,
-} from '../../../utils/mockDataUtils';
+import { fakeEnrolment, fakeRegistration } from '../../../utils/mockDataUtils';
 import { registration } from '../../registration/__mocks__/registration';
 import {
   ENROLMENT_INITIAL_VALUES,
@@ -9,8 +6,10 @@ import {
   NOTIFICATION_TYPE,
 } from '../constants';
 import {
-  getEnrolmentFormInitialValues,
+  getEnrolmentDefaultInitialValues,
+  getEnrolmentInitialValues,
   getEnrolmentNotificationsCode,
+  getEnrolmentNotificationTypes,
   getEnrolmentPayload,
 } from '../utils';
 
@@ -100,10 +99,10 @@ describe('getEnrolmentPayload function', () => {
   });
 });
 
-describe('getEnrolmentFormInitialValues function', () => {
+describe('getEnrolmentDefaultInitialValues function', () => {
   it('should return enrolment initial values', () => {
     expect(
-      getEnrolmentFormInitialValues(
+      getEnrolmentDefaultInitialValues(
         fakeRegistration({
           audience_max_age: 18,
           audience_min_age: 8,
@@ -128,7 +127,7 @@ describe('getEnrolmentFormInitialValues function', () => {
     });
 
     expect(
-      getEnrolmentFormInitialValues(
+      getEnrolmentDefaultInitialValues(
         fakeRegistration({
           audience_max_age: null,
           audience_min_age: null,
@@ -151,5 +150,139 @@ describe('getEnrolmentFormInitialValues function', () => {
       streetAddress: '',
       zip: '',
     });
+  });
+});
+
+describe('getEnrolmentInitialValues function', () => {
+  it('should return default values if value is not set', () => {
+    const {
+      audienceMaxAge,
+      audienceMinAge,
+      city,
+      dateOfBirth,
+      email,
+      extraInfo,
+      membershipNumber,
+      name,
+      nativeLanguage,
+      notifications,
+      phoneNumber,
+      serviceLanguage,
+      streetAddress,
+      zip,
+    } = getEnrolmentInitialValues(
+      fakeEnrolment({
+        city: null,
+        date_of_birth: null,
+        email: null,
+        extra_info: null,
+        membership_number: null,
+        name: null,
+        native_language: null,
+        notifications: NOTIFICATION_TYPE.NO_NOTIFICATION,
+        phone_number: null,
+        service_language: null,
+        street_address: null,
+        zipcode: null,
+      }),
+      fakeRegistration({ audience_min_age: null, audience_max_age: null })
+    );
+
+    expect(audienceMaxAge).toBe(null);
+    expect(audienceMinAge).toBe(null);
+    expect(city).toBe('-');
+    expect(dateOfBirth).toBe('');
+    expect(email).toBe('-');
+    expect(extraInfo).toBe('-');
+    expect(membershipNumber).toBe('-');
+    expect(name).toBe('-');
+    expect(nativeLanguage).toBe('');
+    expect(notifications).toEqual([]);
+    expect(phoneNumber).toBe('-');
+    expect(serviceLanguage).toBe('');
+    expect(streetAddress).toBe('-');
+    expect(zip).toBe('-');
+  });
+
+  it('should return enrolment initial values', () => {
+    const expectedCity = 'City';
+    const expectedDateOfBirth = '10.10.2021';
+    const expectedEmail = 'user@email.com';
+    const expectedExtraInfo = 'Extra info';
+    const expectedMembershipNumber = 'XXX-XXX-XXX';
+    const expectedName = 'Name';
+    const expectedNativeLanguage = 'fi';
+    const expectedNotifications = [NOTIFICATIONS.EMAIL, NOTIFICATIONS.SMS];
+    const expectedPhoneNumber = '+358 44 123 4567';
+    const expectedServiceLanguage = 'sv';
+    const expectedStreetAddress = 'Test address';
+    const expectedZip = '12345';
+
+    const {
+      audienceMaxAge,
+      audienceMinAge,
+      city,
+      dateOfBirth,
+      email,
+      extraInfo,
+      membershipNumber,
+      name,
+      nativeLanguage,
+      notifications,
+      phoneNumber,
+      serviceLanguage,
+      streetAddress,
+      zip,
+    } = getEnrolmentInitialValues(
+      fakeEnrolment({
+        city: expectedCity,
+        date_of_birth: '2021-10-10',
+        email: expectedEmail,
+        extra_info: expectedExtraInfo,
+        membership_number: expectedMembershipNumber,
+        name: expectedName,
+        native_language: expectedNativeLanguage,
+        notifications: NOTIFICATION_TYPE.SMS_EMAIL,
+        phone_number: expectedPhoneNumber,
+        service_language: expectedServiceLanguage,
+        street_address: expectedStreetAddress,
+        zipcode: expectedZip,
+      }),
+      registration
+    );
+
+    expect(audienceMaxAge).toBe(18);
+    expect(audienceMinAge).toBe(8);
+    expect(city).toBe(expectedCity);
+    expect(dateOfBirth).toEqual(expectedDateOfBirth);
+    expect(email).toBe(expectedEmail);
+    expect(extraInfo).toBe(expectedExtraInfo);
+    expect(membershipNumber).toBe(expectedMembershipNumber);
+    expect(name).toBe(expectedName);
+    expect(nativeLanguage).toBe(expectedNativeLanguage);
+    expect(notifications).toEqual(expectedNotifications);
+    expect(phoneNumber).toBe(expectedPhoneNumber);
+    expect(serviceLanguage).toBe(expectedServiceLanguage);
+    expect(streetAddress).toBe(expectedStreetAddress);
+    expect(zip).toBe(expectedZip);
+  });
+});
+
+describe('getEnrolmentNotificationTypes function', () => {
+  it('should return correct notification types', () => {
+    expect(
+      getEnrolmentNotificationTypes(NOTIFICATION_TYPE.NO_NOTIFICATION)
+    ).toEqual([]);
+    expect(getEnrolmentNotificationTypes(NOTIFICATION_TYPE.SMS)).toEqual([
+      NOTIFICATIONS.SMS,
+    ]);
+    expect(getEnrolmentNotificationTypes(NOTIFICATION_TYPE.EMAIL)).toEqual([
+      NOTIFICATIONS.EMAIL,
+    ]);
+    expect(getEnrolmentNotificationTypes(NOTIFICATION_TYPE.SMS_EMAIL)).toEqual([
+      NOTIFICATIONS.EMAIL,
+      NOTIFICATIONS.SMS,
+    ]);
+    expect(getEnrolmentNotificationTypes('lorem ipsum')).toEqual([]);
   });
 });

--- a/src/domain/enrolment/constants.ts
+++ b/src/domain/enrolment/constants.ts
@@ -57,3 +57,7 @@ export enum NOTIFICATION_TYPE {
   EMAIL = 'email',
   SMS_EMAIL = 'sms and email',
 }
+
+export enum ENROLMENT_EDIT_ACTIONS {
+  CANCEL = 'cancel',
+}

--- a/src/domain/enrolment/editEnrolmentPageMeta/EditEnrolmentPageMeta.tsx
+++ b/src/domain/enrolment/editEnrolmentPageMeta/EditEnrolmentPageMeta.tsx
@@ -1,0 +1,51 @@
+import Head from 'next/head';
+import React from 'react';
+
+import useLocale from '../../../hooks/useLocale';
+import getLocalisedString from '../../../utils/getLocalisedString';
+import { Event } from '../../event/types';
+import { getEventFields } from '../../event/utils';
+
+interface Props {
+  event: Event;
+}
+
+const EditEnrolmentPageMeta: React.FC<Props> = ({ event }) => {
+  const locale = useLocale();
+
+  const {
+    keywords,
+    name,
+    imageUrl: image,
+    shortDescription: description,
+  } = getEventFields(event, locale);
+
+  const openGraphProperties = {
+    description: description,
+    image: image as string,
+    title: name,
+  };
+
+  return (
+    <Head>
+      <title>{name}</title>
+      <meta name="description" content={description} />
+      <meta
+        name="keywords"
+        content={keywords
+          .map((keyword) =>
+            getLocalisedString(keyword.name, locale).toLowerCase()
+          )
+          .join(', ')}
+      />
+      <meta name="twitter:card" content="summary" />
+      {Object.entries(openGraphProperties)
+        .filter((p) => p)
+        .map(([property, value]) => (
+          <meta key={property} property={`og:${property}`} content={value} />
+        ))}
+    </Head>
+  );
+};
+
+export default EditEnrolmentPageMeta;

--- a/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
+++ b/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
@@ -1,5 +1,5 @@
 import { Field, Form, Formik } from 'formik';
-import { Fieldset, Notification } from 'hds-react';
+import { Fieldset, IconCross, Notification } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
 import React from 'react';
@@ -17,29 +17,77 @@ import TextInputField from '../../../common/components/formFields/TextInputField
 import FormGroup from '../../../common/components/formGroup/FormGroup';
 import ServerErrorSummary from '../../../common/components/serverErrorSummary/ServerErrorSummary';
 import useLocale from '../../../hooks/useLocale';
+import useMountedState from '../../../hooks/useMountedState';
 import { ROUTES } from '../../app/routes/constants';
 import { Registration } from '../../registration/types';
-import {
-  getRegistrationWarning,
-  isRegistrationPossible,
-} from '../../registration/utils';
+import { isRegistrationPossible } from '../../registration/utils';
 import { ENROLMENT_FIELDS, NOTIFICATIONS } from '../constants';
 import useEnrolmentServerErrors from '../hooks/useEnrolmentServerErrors';
 import useLanguageOptions from '../hooks/useLanguageOptions';
 import useNotificationOptions from '../hooks/useNotificationOptions';
-import { useCreateEnrolmentMutation } from '../mutation';
-import { Enrolment } from '../types';
-import { getEnrolmentFormInitialValues, getEnrolmentPayload } from '../utils';
+import ConfirmCancelModal from '../modals/ConfirmCancelModal';
+import {
+  useCreateEnrolmentMutation,
+  useDeleteEnrolmentMutation,
+} from '../mutation';
+import RegistrationWarning from '../registrationWarning/RegistrationWarning';
+import { Enrolment, EnrolmentFormFields } from '../types';
+import { getEnrolmentPayload } from '../utils';
 import { enrolmentSchema, scrollToFirstError, showErrors } from '../validation';
 import styles from './enrolmentForm.module.scss';
-import RegistrationWarning from '../registrationWarning/RegistrationWarning';
+
+export enum ENROLMENT_MODALS {
+  CANCEL = 'cancel',
+}
+
+interface Callbacks {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onError?: (error: any) => void;
+  onSuccess?: () => void;
+}
 
 type Props = {
+  cancellationCode?: string;
+  initialValues: EnrolmentFormFields;
+  readOnly?: boolean;
   registration: Registration;
 };
 
-const EnrolmentForm: React.FC<Props> = ({ registration }) => {
+const EnrolmentForm: React.FC<Props> = ({
+  cancellationCode,
+  initialValues,
+  readOnly,
+  registration,
+}) => {
   const { t } = useTranslation(['enrolment', 'common']);
+
+  const [openModal, setOpenModal] = useMountedState<ENROLMENT_MODALS | null>(
+    null
+  );
+
+  const closeModal = () => {
+    setOpenModal(null);
+  };
+
+  const cleanAfterUpdate = async (callbacks?: Callbacks) => {
+    closeModal();
+    // Call callback function if defined
+    await (callbacks?.onSuccess && callbacks.onSuccess());
+  };
+
+  const handleError = ({
+    callbacks,
+    error,
+  }: {
+    callbacks?: Callbacks;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    error: any;
+  }) => {
+    closeModal();
+    // Call callback function if defined
+    callbacks?.onError?.(error);
+  };
+
   const notificationOptions = useNotificationOptions();
   const languageOptions = useLanguageOptions();
   const formDisabled = !isRegistrationPossible(registration);
@@ -59,6 +107,16 @@ const EnrolmentForm: React.FC<Props> = ({ registration }) => {
         .replace('[accessCode]', enrolment.cancellation_code as string)}`
     );
   };
+
+  const goToEnrolmentCancelledPage = () => {
+    router.push(
+      `/${locale}${ROUTES.ENROLMENT_CANCELLED.replace(
+        '[registrationId]',
+        registration.id
+      )}`
+    );
+  };
+
   const createEnrolmentMutation = useCreateEnrolmentMutation({
     onError: (error) => {
       showServerErrors({ error: JSON.parse(error.message) });
@@ -68,15 +126,30 @@ const EnrolmentForm: React.FC<Props> = ({ registration }) => {
     },
   });
 
-  const registrationWarning = getRegistrationWarning(registration, t);
+  const deleteEnrolmentMutation = useDeleteEnrolmentMutation({
+    onError: (error) => {
+      handleError({
+        callbacks: {
+          onError: () => showServerErrors({ error: JSON.parse(error.message) }),
+        },
+        error,
+      });
+    },
+    onSuccess: () => {
+      cleanAfterUpdate({ onSuccess: () => goToEnrolmentCancelledPage() });
+    },
+  });
 
-  const initialValues = getEnrolmentFormInitialValues(registration);
+  const handleCancel = () => {
+    setServerErrorItems([]);
+    deleteEnrolmentMutation.mutate(cancellationCode as string);
+  };
 
   return (
     <Formik
       initialValues={initialValues}
       onSubmit={/* istanbul ignore next */ () => undefined}
-      validationSchema={enrolmentSchema}
+      validationSchema={readOnly ? undefined : enrolmentSchema}
     >
       {({ setErrors, setTouched, values }) => {
         const clearErrors = () => setErrors({});
@@ -102,181 +175,225 @@ const EnrolmentForm: React.FC<Props> = ({ registration }) => {
         };
 
         return (
-          <Form noValidate>
-            <ServerErrorSummary errors={serverErrorItems} />
-            <RegistrationWarning registration={registration} />
-            <Fieldset heading={t(`titleBasicInfo`)}>
-              <FormGroup>
-                <Field
-                  name={ENROLMENT_FIELDS.NAME}
-                  component={TextInputField}
-                  disabled={formDisabled}
-                  label={t(`labelName`)}
-                  placeholder={t(`placeholderName`)}
-                  required
-                />
-              </FormGroup>
-              <FormGroup>
-                <div className={styles.streetAddressRow}>
+          <>
+            <ConfirmCancelModal
+              isOpen={openModal === ENROLMENT_MODALS.CANCEL}
+              onCancel={handleCancel}
+              onClose={closeModal}
+            />
+            <Form noValidate>
+              <ServerErrorSummary errors={serverErrorItems} />
+              <RegistrationWarning registration={registration} />
+              <Fieldset heading={t(`titleBasicInfo`)}>
+                <FormGroup>
                   <Field
-                    name={ENROLMENT_FIELDS.STREET_ADDRESS}
+                    name={ENROLMENT_FIELDS.NAME}
                     component={TextInputField}
                     disabled={formDisabled}
-                    label={t(`labelStreetAddress`)}
-                    placeholder={t(`placeholderStreetAddress`)}
+                    label={t(`labelName`)}
+                    placeholder={readOnly ? '' : t(`placeholderName`)}
+                    readOnly={readOnly}
                     required
                   />
-                  <Field
-                    name={ENROLMENT_FIELDS.DATE_OF_BIRTH}
-                    component={DateInputField}
-                    disabled={formDisabled}
-                    label={t(`labelDateOfBirth`)}
-                    language={locale}
-                    maxDate={new Date()}
-                    minDate={
-                      new Date(`${new Date().getFullYear() - 100}-01-01`)
-                    }
-                    placeholder={t(`placeholderDateOfBirth`)}
-                    required
-                  />
-                </div>
-              </FormGroup>
-              <FormGroup>
-                <div className={styles.zipRow}>
-                  <Field
-                    name={ENROLMENT_FIELDS.ZIP}
-                    component={TextInputField}
-                    disabled={formDisabled}
-                    label={t(`labelZip`)}
-                    placeholder={t(`placeholderZip`)}
-                    required
-                  />
-                  <Field
-                    name={ENROLMENT_FIELDS.CITY}
-                    component={TextInputField}
-                    disabled={formDisabled}
-                    label={t(`labelCity`)}
-                    placeholder={t(`placeholderCity`)}
-                    required
-                  />
-                </div>
-              </FormGroup>
-            </Fieldset>
+                </FormGroup>
+                <FormGroup>
+                  <div className={styles.streetAddressRow}>
+                    <Field
+                      name={ENROLMENT_FIELDS.STREET_ADDRESS}
+                      component={TextInputField}
+                      disabled={formDisabled}
+                      label={t(`labelStreetAddress`)}
+                      placeholder={
+                        readOnly ? '' : t(`placeholderStreetAddress`)
+                      }
+                      readOnly={readOnly}
+                      required
+                    />
+                    <Field
+                      name={ENROLMENT_FIELDS.DATE_OF_BIRTH}
+                      component={DateInputField}
+                      disabled={formDisabled}
+                      label={t(`labelDateOfBirth`)}
+                      language={locale}
+                      maxDate={new Date()}
+                      minDate={
+                        new Date(`${new Date().getFullYear() - 100}-01-01`)
+                      }
+                      placeholder={readOnly ? '' : t(`placeholderDateOfBirth`)}
+                      readOnly={readOnly}
+                      required
+                    />
+                  </div>
+                </FormGroup>
+                <FormGroup>
+                  <div className={styles.zipRow}>
+                    <Field
+                      name={ENROLMENT_FIELDS.ZIP}
+                      component={TextInputField}
+                      disabled={formDisabled}
+                      label={t(`labelZip`)}
+                      placeholder={readOnly ? '' : t(`placeholderZip`)}
+                      readOnly={readOnly}
+                      required
+                    />
+                    <Field
+                      name={ENROLMENT_FIELDS.CITY}
+                      component={TextInputField}
+                      disabled={formDisabled}
+                      label={t(`labelCity`)}
+                      placeholder={readOnly ? '' : t(`placeholderCity`)}
+                      readOnly={readOnly}
+                      required
+                    />
+                  </div>
+                </FormGroup>
+              </Fieldset>
 
-            <Fieldset heading={t(`titleContactInfo`)}>
-              <FormGroup>
-                <div className={styles.emailRow}>
-                  <Field
-                    name={ENROLMENT_FIELDS.EMAIL}
-                    component={TextInputField}
-                    disabled={formDisabled}
-                    label={t(`labelEmail`)}
-                    placeholder={t(`placeholderEmail`)}
-                    required={values.notifications.includes(
-                      NOTIFICATIONS.EMAIL
-                    )}
-                  />
-                  <Field
-                    name={ENROLMENT_FIELDS.PHONE_NUMBER}
-                    component={PhoneInputField}
-                    disabled={formDisabled}
-                    label={t(`labelPhoneNumber`)}
-                    placeholder={t(`placeholderPhoneNumber`)}
-                    type="tel"
-                    required={values.notifications.includes(NOTIFICATIONS.SMS)}
-                  />
-                </div>
-              </FormGroup>
-            </Fieldset>
+              <Fieldset heading={t(`titleContactInfo`)}>
+                <FormGroup>
+                  <div className={styles.emailRow}>
+                    <Field
+                      name={ENROLMENT_FIELDS.EMAIL}
+                      component={TextInputField}
+                      disabled={formDisabled}
+                      label={t(`labelEmail`)}
+                      placeholder={readOnly ? '' : t(`placeholderEmail`)}
+                      readOnly={readOnly}
+                      required={values.notifications.includes(
+                        NOTIFICATIONS.EMAIL
+                      )}
+                    />
+                    <Field
+                      name={ENROLMENT_FIELDS.PHONE_NUMBER}
+                      component={PhoneInputField}
+                      disabled={formDisabled}
+                      label={t(`labelPhoneNumber`)}
+                      placeholder={readOnly ? '' : t(`placeholderPhoneNumber`)}
+                      readOnly={readOnly}
+                      required={values.notifications.includes(
+                        NOTIFICATIONS.SMS
+                      )}
+                      type="tel"
+                    />
+                  </div>
+                </FormGroup>
+              </Fieldset>
 
-            <Fieldset heading={t(`titleNotifications`)}>
-              <FormGroup>
-                <Field
-                  name={ENROLMENT_FIELDS.NOTIFICATIONS}
-                  className={styles.notifications}
-                  component={CheckboxGroupField}
-                  disabled={formDisabled}
-                  options={notificationOptions}
-                />
-              </FormGroup>
-            </Fieldset>
+              <Fieldset heading={t(`titleNotifications`)}>
+                <FormGroup>
+                  <Field
+                    name={ENROLMENT_FIELDS.NOTIFICATIONS}
+                    className={styles.notifications}
+                    component={CheckboxGroupField}
+                    disabled={formDisabled || readOnly}
+                    options={notificationOptions}
+                  />
+                </FormGroup>
+              </Fieldset>
 
-            <Fieldset heading={t(`titleAdditionalInfo`)}>
-              <FormGroup>
-                <div className={styles.membershipNumberRow}>
+              <Fieldset heading={t(`titleAdditionalInfo`)}>
+                <FormGroup>
+                  <div className={styles.membershipNumberRow}>
+                    <Field
+                      name={ENROLMENT_FIELDS.MEMBERSHIP_NUMBER}
+                      component={TextInputField}
+                      disabled={formDisabled}
+                      label={t(`labelMembershipNumber`)}
+                      placeholder={
+                        readOnly ? '' : t(`placeholderMembershipNumber`)
+                      }
+                      readOnly={readOnly}
+                    />
+                  </div>
+                </FormGroup>
+                <FormGroup>
+                  <div className={styles.nativeLanguageRow}>
+                    <Field
+                      name={ENROLMENT_FIELDS.NATIVE_LANGUAGE}
+                      component={SingleSelectField}
+                      disabled={formDisabled || readOnly}
+                      label={t(`labelNativeLanguage`)}
+                      options={languageOptions}
+                      placeholder={
+                        readOnly ? '' : t(`placeholderNativeLanguage`)
+                      }
+                      readOnly={readOnly}
+                      required
+                    />
+                    <Field
+                      name={ENROLMENT_FIELDS.SERVICE_LANGUAGE}
+                      component={SingleSelectField}
+                      disabled={formDisabled || readOnly}
+                      label={t(`labelServiceLanguage`)}
+                      options={languageOptions}
+                      placeholder={
+                        readOnly ? '' : t(`placeholderServiceLanguage`)
+                      }
+                      required
+                    />
+                  </div>
+                </FormGroup>
+                <FormGroup>
                   <Field
-                    name={ENROLMENT_FIELDS.MEMBERSHIP_NUMBER}
-                    component={TextInputField}
+                    name={ENROLMENT_FIELDS.EXTRA_INFO}
+                    component={TextAreaField}
                     disabled={formDisabled}
-                    label={t(`labelMembershipNumber`)}
-                    placeholder={t(`placeholderMembershipNumber`)}
+                    label={t(`labelExtraInfo`)}
+                    placeholder={readOnly ? '' : t(`placeholderExtraInfo`)}
+                    readOnly={readOnly}
                   />
-                </div>
-              </FormGroup>
-              <FormGroup>
-                <div className={styles.nativeLanguageRow}>
-                  <Field
-                    name={ENROLMENT_FIELDS.NATIVE_LANGUAGE}
-                    component={SingleSelectField}
-                    disabled={formDisabled}
-                    label={t(`labelNativeLanguage`)}
-                    options={languageOptions}
-                    placeholder={t(`placeholderNativeLanguage`)}
-                    required
-                  />
-                  <Field
-                    name={ENROLMENT_FIELDS.SERVICE_LANGUAGE}
-                    component={SingleSelectField}
-                    disabled={formDisabled}
-                    label={t(`labelServiceLanguage`)}
-                    options={languageOptions}
-                    placeholder={t(`placeholderServiceLanguage`)}
-                    required
-                  />
-                </div>
-              </FormGroup>
-              <FormGroup>
-                <Field
-                  name={ENROLMENT_FIELDS.EXTRA_INFO}
-                  component={TextAreaField}
-                  disabled={formDisabled}
-                  label={t(`labelExtraInfo`)}
-                  placeholder={t(`placeholderExtraInfo`)}
-                />
-              </FormGroup>
-            </Fieldset>
-            <FormGroup>
-              <Field
-                disabled={formDisabled}
-                label={t(`labelAccepted`)}
-                name={ENROLMENT_FIELDS.ACCEPTED}
-                component={CheckboxField}
-              />
-            </FormGroup>
+                </FormGroup>
+              </Fieldset>
+              {!readOnly && (
+                <>
+                  <FormGroup>
+                    <Field
+                      disabled={formDisabled}
+                      label={t(`labelAccepted`)}
+                      name={ENROLMENT_FIELDS.ACCEPTED}
+                      component={CheckboxField}
+                    />
+                  </FormGroup>
 
-            <Notification
-              className={styles.notification}
-              label={t('notificationTitle')}
-            >
-              <div
-                dangerouslySetInnerHTML={{
-                  __html: t('notificationLabel', {
-                    openInNewTab: t('common:openInNewTab'),
-                    url: t('linkPrivacyPolicy'),
-                  }),
-                }}
-              ></div>
-            </Notification>
-            <div className={styles.buttonWrapper}>
-              <Button
-                className={styles.button}
-                disabled={formDisabled}
-                onClick={handleSubmit}
-              >
-                {t('buttonSend')}
-              </Button>
-            </div>
-          </Form>
+                  <Notification
+                    className={styles.notification}
+                    label={t('notificationTitle')}
+                  >
+                    <div
+                      dangerouslySetInnerHTML={{
+                        __html: t('notificationLabel', {
+                          openInNewTab: t('common:openInNewTab'),
+                          url: t('linkPrivacyPolicy'),
+                        }),
+                      }}
+                    ></div>
+                  </Notification>
+                  <div className={styles.buttonWrapper}>
+                    <Button
+                      className={styles.button}
+                      disabled={formDisabled}
+                      onClick={handleSubmit}
+                    >
+                      {t('buttonSend')}
+                    </Button>
+                  </div>
+                </>
+              )}
+              {readOnly && (
+                <div className={styles.buttonWrapper}>
+                  <Button
+                    className={styles.button}
+                    disabled={formDisabled}
+                    iconLeft={<IconCross aria-hidden={true} />}
+                    onClick={() => setOpenModal(ENROLMENT_MODALS.CANCEL)}
+                    variant={'danger'}
+                  >
+                    {t('buttonCancel')}
+                  </Button>
+                </div>
+              )}
+            </Form>
+          </>
         );
       }}
     </Formik>

--- a/src/domain/enrolment/modals/ConfirmCancelModal.tsx
+++ b/src/domain/enrolment/modals/ConfirmCancelModal.tsx
@@ -1,0 +1,58 @@
+import { Dialog, IconAlertCircle } from 'hds-react';
+import { useTranslation } from 'next-i18next';
+import React from 'react';
+
+import Button from '../../../common/components/button/Button';
+import styles from './modals.module.scss';
+
+export interface ConfirmCancelModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onCancel: () => void;
+}
+
+const ConfirmCancelModal: React.FC<ConfirmCancelModalProps> = ({
+  isOpen,
+  onClose,
+  onCancel,
+}) => {
+  const { t } = useTranslation(['enrolment', 'common']);
+  const openConfirmationButtonRef = React.useRef(null);
+  const id = 'cancel-confirmation-dialog';
+  const titleId = 'cancel-confirmation-dialog-title';
+  const descriptionId = 'cancel-confirmation-dialog-description';
+
+  return (
+    <Dialog
+      id={id}
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
+      className={styles.dialog}
+      isOpen={isOpen}
+      focusAfterCloseRef={openConfirmationButtonRef}
+      variant="danger"
+    >
+      <Dialog.Header
+        id={titleId}
+        title={t('enrolment:cancelEnrolmentModal.title')}
+        iconLeft={<IconAlertCircle aria-hidden="true" />}
+      />
+      <Dialog.Content>
+        <p className={styles.warning}>
+          <strong>{t('common:warning')}</strong>
+        </p>
+        <p id={descriptionId}>{t('enrolment:cancelEnrolmentModal.text')} </p>
+      </Dialog.Content>
+      <Dialog.ActionButtons>
+        <Button onClick={onCancel} variant="danger">
+          {t('enrolment:cancelEnrolmentModal.buttonCancel')}
+        </Button>
+        <Button onClick={onClose} theme={'black'} variant="secondary">
+          {t('common:cancel')}
+        </Button>
+      </Dialog.ActionButtons>
+    </Dialog>
+  );
+};
+
+export default ConfirmCancelModal;

--- a/src/domain/enrolment/modals/modals.module.scss
+++ b/src/domain/enrolment/modals/modals.module.scss
@@ -1,0 +1,8 @@
+.dialog {
+  line-height: var(--lineheight-l);
+}
+
+.warning {
+  margin-bottom: calc(0px - var(--spacing-s));
+  text-transform: uppercase;
+}

--- a/src/domain/enrolment/mutation.ts
+++ b/src/domain/enrolment/mutation.ts
@@ -5,10 +5,19 @@ import {
 } from 'react-query';
 
 import { CreateEnrolmentMutationInput, Enrolment } from './types';
-import { createEnrolment } from './utils';
+import { createEnrolment, deleteEnrolment } from './utils';
 
 export const useCreateEnrolmentMutation = (
   options?: UseMutationOptions<Enrolment, Error, CreateEnrolmentMutationInput>
 ): UseMutationResult<Enrolment, Error, CreateEnrolmentMutationInput> => {
   return useMutation((input) => createEnrolment(input), options);
+};
+
+export const useDeleteEnrolmentMutation = (
+  options?: UseMutationOptions<null, Error, string>
+): UseMutationResult<null, Error, string> => {
+  return useMutation(
+    (cancellationCode) => deleteEnrolment(cancellationCode),
+    options
+  );
 };

--- a/src/domain/enrolment/utils.ts
+++ b/src/domain/enrolment/utils.ts
@@ -33,6 +33,23 @@ export const createEnrolment = (
   );
 };
 
+export const deleteEnrolment = (cancellationCode: string): Promise<null> => {
+  return fetch(getLinkedEventsUrl('/signup/'), {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ cancellation_code: cancellationCode }),
+  }).then((res) =>
+    res.json().then((data) => {
+      if (!res.ok) {
+        throw Error(JSON.stringify(data));
+      }
+      return data;
+    })
+  );
+};
+
 export const getEnrolmentNotificationsCode = (
   notifications: string[]
 ): NOTIFICATION_TYPE => {
@@ -47,6 +64,21 @@ export const getEnrolmentNotificationsCode = (
     return NOTIFICATION_TYPE.SMS;
   } else {
     return NOTIFICATION_TYPE.NO_NOTIFICATION;
+  }
+};
+
+export const getEnrolmentNotificationTypes = (
+  notifications: string
+): NOTIFICATIONS[] => {
+  switch (notifications) {
+    case NOTIFICATION_TYPE.SMS:
+      return [NOTIFICATIONS.SMS];
+    case NOTIFICATION_TYPE.EMAIL:
+      return [NOTIFICATIONS.EMAIL];
+    case NOTIFICATION_TYPE.SMS_EMAIL:
+      return [NOTIFICATIONS.EMAIL, NOTIFICATIONS.SMS];
+    default:
+      return [];
   }
 };
 
@@ -88,10 +120,36 @@ export const getEnrolmentPayload = (
   };
 };
 
-export const getEnrolmentFormInitialValues = (
+export const getEnrolmentDefaultInitialValues = (
   registration: Registration
 ): EnrolmentFormFields => ({
   ...ENROLMENT_INITIAL_VALUES,
   audienceMaxAge: registration.audience_max_age ?? null,
   audienceMinAge: registration.audience_min_age ?? null,
 });
+
+export const getEnrolmentInitialValues = (
+  enrolment: Enrolment,
+  registration: Registration
+): EnrolmentFormFields => {
+  return {
+    ...getEnrolmentDefaultInitialValues(registration),
+    accepted: true,
+    city: enrolment.city ?? '-',
+    dateOfBirth: enrolment.date_of_birth
+      ? formatDate(new Date(enrolment.date_of_birth))
+      : '',
+    email: enrolment.email ?? '-',
+    extraInfo: enrolment.extra_info ?? '-',
+    membershipNumber: enrolment.membership_number ?? '-',
+    name: enrolment.name ?? '-',
+    nativeLanguage: enrolment.native_language ?? '',
+    notifications: getEnrolmentNotificationTypes(
+      enrolment.notifications as string
+    ),
+    phoneNumber: enrolment.phone_number ?? '-',
+    serviceLanguage: enrolment.service_language ?? '',
+    streetAddress: enrolment.street_address ?? '-',
+    zip: enrolment.zipcode ?? '-',
+  };
+};

--- a/src/hooks/useIsMounted.ts
+++ b/src/hooks/useIsMounted.ts
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const useIsMounted = (): React.MutableRefObject<boolean> => {
+  const isMounted = React.useRef(false);
+
+  React.useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  return isMounted;
+};
+
+export default useIsMounted;

--- a/src/hooks/useMountedState.ts
+++ b/src/hooks/useMountedState.ts
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import useIsMounted from './useIsMounted';
+
+function useMountedState<S>(
+  initialState: S | (() => S)
+): [S, (state: S) => void] {
+  const isMounted = useIsMounted();
+  const [state, setState] = React.useState<S>(initialState);
+
+  const setMountedState = (state: S) => {
+    /* istanbul ignore else */
+    if (isMounted.current) {
+      setState(state);
+    }
+  };
+
+  return [state, setMountedState];
+}
+
+export default useMountedState;

--- a/src/pages/registration/[registrationId]/enrolment/[enrolmentId]/edit/[accessCode]/index.tsx
+++ b/src/pages/registration/[registrationId]/enrolment/[enrolmentId]/edit/[accessCode]/index.tsx
@@ -1,0 +1,42 @@
+import { GetServerSideProps, NextPage } from 'next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import { dehydrate, QueryClient } from 'react-query';
+
+import EditEnrolmentPage from '../../../../../../../domain/enrolment/EditEnrolmentPage';
+import { EVENT_INCLUDES } from '../../../../../../../domain/event/constants';
+import { prefetchEventQuery } from '../../../../../../../domain/event/query';
+import { fetchRegistrationQuery } from '../../../../../../../domain/registration/query';
+
+const EditEnrolment: NextPage = () => <EditEnrolmentPage />;
+
+export const getServerSideProps: GetServerSideProps = async ({
+  locale,
+  query,
+}) => {
+  const queryClient = new QueryClient();
+
+  try {
+    const registration = await fetchRegistrationQuery(queryClient, {
+      id: query.registrationId as string,
+    });
+
+    if (registration?.event) {
+      await prefetchEventQuery(queryClient, {
+        id: registration?.event,
+        include: EVENT_INCLUDES,
+      });
+    }
+  } catch {}
+
+  return {
+    props: {
+      ...(await serverSideTranslations(locale as string, [
+        'common',
+        'enrolment',
+      ])),
+      dehydratedState: dehydrate(queryClient),
+    },
+  };
+};
+
+export default EditEnrolment;

--- a/src/pages/registration/[registrationId]/enrolment/cancelled/index.tsx
+++ b/src/pages/registration/[registrationId]/enrolment/cancelled/index.tsx
@@ -1,0 +1,42 @@
+import { GetServerSideProps, NextPage } from 'next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import { dehydrate, QueryClient } from 'react-query';
+
+import EnrolmentCancelledPage from '../../../../../domain/enrolment/EnrolmentCancelledPage';
+import { EVENT_INCLUDES } from '../../../../../domain/event/constants';
+import { prefetchEventQuery } from '../../../../../domain/event/query';
+import { fetchRegistrationQuery } from '../../../../../domain/registration/query';
+
+const EnrolmentCancelled: NextPage = () => <EnrolmentCancelledPage />;
+
+export const getServerSideProps: GetServerSideProps = async ({
+  locale,
+  query,
+}) => {
+  const queryClient = new QueryClient();
+
+  try {
+    const registration = await fetchRegistrationQuery(queryClient, {
+      id: query.registrationId as string,
+    });
+
+    if (registration?.event) {
+      await prefetchEventQuery(queryClient, {
+        id: registration?.event,
+        include: EVENT_INCLUDES,
+      });
+    }
+  } catch {}
+
+  return {
+    props: {
+      ...(await serverSideTranslations(locale as string, [
+        'common',
+        'enrolment',
+      ])),
+      dehydratedState: dehydrate(queryClient),
+    },
+  };
+};
+
+export default EnrolmentCancelled;


### PR DESCRIPTION
## Description
Read-only view of enrolment form
Edit enrolment page with cancel enrolment button
Enrolment cancelled page

## Closes 
[LINK-684](https://helsinkisolutionoffice.atlassian.net/browse/LINK-684)

## Screenshots
<img width="1219" alt="Screenshot 2021-12-15 at 13 47 34" src="https://user-images.githubusercontent.com/24706814/146181138-b29472d0-5351-4b8b-8770-f0e6e14ecf83.png">

<img width="621" alt="Screenshot 2021-12-15 at 13 47 40" src="https://user-images.githubusercontent.com/24706814/146181161-e13cdf68-1e28-44a3-9d20-4b16f2fadd66.png">


<img width="1248" alt="Screenshot 2021-12-15 at 13 47 50" src="https://user-images.githubusercontent.com/24706814/146181196-3cbd302e-d77f-44bb-9957-234f0bdfa07d.png">

## Testing
Create new enrolment from page http://localhost:3000/fi/registration/13/enrolment/create
Go to edit enrolment page by changing e.g. http://localhost:3000/fi/registration/13/enrolment/39/completed/477309ee-a7d6-4730-94f1-c70f6f2fbd26 http://localhost:3000/fi/registration/13/enrolment/39/edit/477309ee-a7d6-4730-94f1-c70f6f2fbd26


