### PR TITLE
LINK-1157 | Update actions/checkout to latest versions to fix deprecation warnings

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build
         uses: andersinno/kolga-build-action@v2
         env:
@@ -47,7 +47,7 @@ jobs:
     needs: build
     name: Production
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: andersinno/kolga-setup-action@v2
 
       - name: Deploy

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build
         uses: andersinno/kolga-build-action@v2
         env:
@@ -42,7 +42,7 @@ jobs:
     needs: build
     name: Review
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: andersinno/kolga-setup-action@v2
 
       - name: Deploy

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build
         uses: andersinno/kolga-build-action@v2
         env:
@@ -46,7 +46,7 @@ jobs:
     needs: build
     name: Staging
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: andersinno/kolga-setup-action@v2
 
       - name: Deploy


### PR DESCRIPTION
## Description :sparkles:
Bump actions/checkout@v2 to actions/checkout@v3 to fix GitHub action deprecation warnings

## Issues :bug:

### Closes :no_good_woman:
[LINK-1157](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1157)

[LINK-1157]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Testing 
Latest GitHub action run can be found at https://github.com/City-of-Helsinki/linkedregistrations-ui/actions/runs/4145212175