### PR TITLE
LINK-1363 | Prevent to reserve seats or signup is enrolment is not open

### DIFF
--- a/public/locales/en/enrolment.json
+++ b/public/locales/en/enrolment.json
@@ -87,6 +87,7 @@
   "titleNotifications": "Event notifications",
   "titleRegistration": "Registration",
   "warnings": {
+    "allSeatsReserved": "All seats in the event are currently booked. Please try again later.",
     "capacityInWaitingList": "Registration for this event is still possible, but there are only {{count}} seat left in the queue.",
     "capacityInWaitingList_other": "Registration for this event is still possible, but there are only {{count}} seats left in the queue.",
     "capacityInWaitingListNoLimit": "Registration for this event is still possible, but there are only seats left in the queue.",

--- a/public/locales/fi/enrolment.json
+++ b/public/locales/fi/enrolment.json
@@ -87,6 +87,7 @@
   "titleNotifications": "Tapahtumaa koskevat ilmoitukset",
   "titleRegistration": "Ilmoittautuminen",
   "warnings": {
+    "allSeatsReserved": "Tapahtuman kaikki paikat ovat tällä hetkellä varatut. Kokeile myöhemmin uudelleen.",
     "capacityInWaitingList": "Ilmoittautuminen tähän tapahtumaan on vielä mahdollista, mutta jonopaikkoja on jäljellä vain {{count}} kpl.",
     "capacityInWaitingList_other": "Ilmoittautuminen tähän tapahtumaan on vielä mahdollista, mutta jonopaikkoja on jäljellä vain {{count}} kpl.",
     "capacityInWaitingListNoLimit": "Ilmoittautuminen tähän tapahtumaan on vielä mahdollista, mutta vain jonopaikkoja on jäljellä.",

--- a/public/locales/sv/enrolment.json
+++ b/public/locales/sv/enrolment.json
@@ -87,6 +87,7 @@
   "titleNotifications": "Evenemangmeddelanden",
   "titleRegistration": "Registrering",
   "warnings": {
+    "allSeatsReserved": "Alla platser i evenemanget är för närvarande bokade. Vänligen försök igen senare.",
     "capacityInWaitingList": "Registrering för detta evenemang är fortfarande möjligt, men det är bara {{count}} plats kvar i kön.",
     "capacityInWaitingList_other": "Registrering för detta evenemang är fortfarande möjligt, men det är bara {{count}} platser kvar i kön.",
     "capacityInWaitingListNoLimit": "Registrering till detta evenemang är fortfarande möjlig, men det finns endast platser kvar i kön.",

--- a/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
+++ b/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
@@ -3,7 +3,7 @@ import { IconCross, SingleSelectProps } from 'hds-react';
 import pick from 'lodash/pick';
 import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { ValidationError } from 'yup';
 import 'react-toastify/dist/ReactToastify.css';
 
@@ -92,10 +92,18 @@ const EnrolmentForm: React.FC<Props> = ({
     useEnrolmentPageContext();
 
   const notificationOptions = useNotificationOptions();
-  const formDisabled = !isRegistrationPossible(registration);
   const locale = useLocale();
   const router = useRouter();
   const { query } = router;
+
+  const formDisabled = useMemo(() => {
+    const data = getSeatsReservationData(registration.id as string);
+    if (data && !isSeatsReservationExpired(data)) {
+      return false;
+    }
+
+    return !isRegistrationPossible(registration);
+  }, [registration]);
 
   const { serverErrorItems, setServerErrorItems, showServerErrors } =
     useEnrolmentServerErrorsContext();
@@ -198,7 +206,7 @@ const EnrolmentForm: React.FC<Props> = ({
               <ServerErrorSummary errors={serverErrorItems} />
               <RegistrationWarning registration={registration} />
 
-              {!readOnly && (
+              {isRegistrationPossible(registration) && !readOnly && (
                 <>
                   <Divider />
                   <ReservationTimer
@@ -207,7 +215,7 @@ const EnrolmentForm: React.FC<Props> = ({
                       reservationTimerCallbacksDisabled.current
                     }
                     disableCallbacks={disableReservationTimerCallbacks}
-                    initReservationData={!enrolment}
+                    initReservationData={true}
                     registration={registration}
                     setAttendees={setAttendees}
                   />

--- a/src/domain/enrolment/enrolmentForm/availableSeatsText/AvailableSeatsText.tsx
+++ b/src/domain/enrolment/enrolmentForm/availableSeatsText/AvailableSeatsText.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'next-i18next';
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 
 import { Registration } from '../../../registration/types';
 import {
@@ -7,6 +7,10 @@ import {
   getFreeWaitingListCapacity,
   isAttendeeCapacityUsed,
 } from '../../../registration/utils';
+import {
+  getSeatsReservationData,
+  isSeatsReservationExpired,
+} from '../../../reserveSeats/utils';
 
 type Props = {
   registration: Registration;
@@ -18,17 +22,22 @@ const AvailableSeatsText: FC<Props> = ({ registration }) => {
   const attendeeCapacityUsed = isAttendeeCapacityUsed(registration);
   const freeWaitingListCapacity = getFreeWaitingListCapacity(registration);
 
+  const reservedSeats = useMemo(() => {
+    const data = getSeatsReservationData(registration.id as string);
+    return data && !isSeatsReservationExpired(data) ? data.seats : 0;
+  }, [registration.id]);
   return (
     <>
       {typeof freeAttendeeCapacity === 'number' && !attendeeCapacityUsed && (
         <p>
-          {t('freeAttendeeCapacity')} <strong>{freeAttendeeCapacity}</strong>
+          {t('freeAttendeeCapacity')}{' '}
+          <strong>{freeAttendeeCapacity + reservedSeats}</strong>
         </p>
       )}
       {attendeeCapacityUsed && typeof freeWaitingListCapacity === 'number' && (
         <p>
           {t('freeWaitingListCapacity')}{' '}
-          <strong>{freeWaitingListCapacity}</strong>
+          <strong>{freeWaitingListCapacity + reservedSeats}</strong>
         </p>
       )}
     </>

--- a/src/domain/enrolment/enrolmentForm/availableSeatsText/__tests__/AvailableSeatsText.test.tsx
+++ b/src/domain/enrolment/enrolmentForm/availableSeatsText/__tests__/AvailableSeatsText.test.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 
-import { fakeRegistration } from '../../../../../utils/mockDataUtils';
+import {
+  fakeRegistration,
+  getMockedSeatsReservationData,
+  setSessionStorageValues,
+} from '../../../../../utils/mockDataUtils';
 import { configure, render, screen } from '../../../../../utils/testUtils';
+import { TEST_REGISTRATION_ID } from '../../../../registration/constants';
 import { Registration } from '../../../../registration/types';
 import AvailableSeatsText from '../AvailableSeatsText';
 
@@ -10,7 +15,7 @@ configure({ defaultHidden: true });
 const renderComponent = (registration: Registration) =>
   render(<AvailableSeatsText registration={registration} />);
 
-test('should show amount of free seats ', () => {
+test('should show amount of free seats', () => {
   renderComponent(
     fakeRegistration({
       maximum_attendee_capacity: 10,
@@ -23,7 +28,7 @@ test('should show amount of free seats ', () => {
   screen.getByText('7');
 });
 
-test('should show amount of remaining seats ', () => {
+test('should show amount of remaining seats', () => {
   renderComponent(
     fakeRegistration({
       maximum_attendee_capacity: 10,
@@ -34,6 +39,21 @@ test('should show amount of remaining seats ', () => {
 
   screen.getByText('Saatavilla olevia paikkoja');
   screen.getByText('0');
+});
+
+test('should show amount of remaining seats if there is reservation stored to session storage', () => {
+  const registration = fakeRegistration({
+    id: TEST_REGISTRATION_ID,
+    maximum_attendee_capacity: 10,
+    current_attendee_count: 3,
+    remaining_attendee_capacity: 0,
+  });
+  const reservation = getMockedSeatsReservationData(1000);
+  setSessionStorageValues(reservation, registration);
+  renderComponent(registration);
+
+  screen.getByText('Saatavilla olevia paikkoja');
+  screen.getByText(reservation.seats);
 });
 
 test('should show amount of free waiting list seats', () => {
@@ -66,4 +86,22 @@ test('should show amount of remaining waiting list seats ', () => {
 
   screen.getByText('Saatavilla olevia jonopaikkoja');
   screen.getByText('0');
+});
+
+test('should show amount of remaining waiting list seats if there is reservation stored to session storage', () => {
+  const registration = fakeRegistration({
+    id: TEST_REGISTRATION_ID,
+    maximum_attendee_capacity: 10,
+    current_attendee_count: 10,
+    current_waiting_list_count: 3,
+    remaining_attendee_capacity: 0,
+    remaining_waiting_list_capacity: 0,
+    waiting_list_capacity: 10,
+  });
+  const reservation = getMockedSeatsReservationData(1000);
+  setSessionStorageValues(reservation, registration);
+  renderComponent(registration);
+
+  screen.getByText('Saatavilla olevia jonopaikkoja');
+  screen.getByText(reservation.seats);
 });

--- a/src/domain/enrolment/registrationWarning/RegistrationWarning.tsx
+++ b/src/domain/enrolment/registrationWarning/RegistrationWarning.tsx
@@ -1,9 +1,13 @@
 import { Notification } from 'hds-react';
 import { useTranslation } from 'next-i18next';
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { Registration } from '../../registration/types';
 import { getRegistrationWarning } from '../../registration/utils';
+import {
+  getSeatsReservationData,
+  isSeatsReservationExpired,
+} from '../../reserveSeats/utils';
 import styles from './registrationWarning.module.scss';
 
 type Props = {
@@ -14,7 +18,12 @@ const RegistrationWarning: React.FC<Props> = ({ registration }) => {
   const { t } = useTranslation(['enrolment']);
   const registrationWarning = getRegistrationWarning(registration, t);
 
-  return registrationWarning ? (
+  const hasReservation = useMemo(() => {
+    const data = getSeatsReservationData(registration.id as string);
+    return Boolean(data && !isSeatsReservationExpired(data));
+  }, [registration.id]);
+
+  return registrationWarning && !hasReservation ? (
     <Notification className={styles.warning}>
       {registrationWarning}
     </Notification>

--- a/src/domain/enrolment/registrationWarning/__tests__/RegistrationWarning.test.tsx
+++ b/src/domain/enrolment/registrationWarning/__tests__/RegistrationWarning.test.tsx
@@ -2,30 +2,48 @@ import addDays from 'date-fns/addDays';
 import subDays from 'date-fns/subDays';
 import React from 'react';
 
-import { fakeRegistration } from '../../../../utils/mockDataUtils';
+import {
+  fakeRegistration,
+  getMockedSeatsReservationData,
+  setSessionStorageValues,
+} from '../../../../utils/mockDataUtils';
 import { render, screen } from '../../../../utils/testUtils';
+import { TEST_REGISTRATION_ID } from '../../../registration/constants';
 import { Registration } from '../../../registration/types';
 import RegistrationWarning from '../RegistrationWarning';
 
 const renderComponent = (registration: Registration) =>
   render(<RegistrationWarning registration={registration} />);
 
-test('should show warning if registration is full', async () => {
-  const now = new Date();
-  const enrolment_start_time = subDays(now, 1).toISOString();
-  const enrolment_end_time = addDays(now, 1).toISOString();
-  const registration = fakeRegistration({
-    current_attendee_count: 10,
-    current_waiting_list_count: 5,
-    enrolment_end_time,
-    enrolment_start_time,
-    maximum_attendee_capacity: 10,
-    waiting_list_capacity: 5,
-  });
+const now = new Date();
+const enrolment_start_time = subDays(now, 1).toISOString();
+const enrolment_end_time = addDays(now, 1).toISOString();
+const registration = fakeRegistration({
+  current_attendee_count: 10,
+  current_waiting_list_count: 5,
+  enrolment_end_time,
+  enrolment_start_time,
+  id: TEST_REGISTRATION_ID,
+  maximum_attendee_capacity: 10,
+  waiting_list_capacity: 5,
+});
 
+test('should show warning if registration is full', async () => {
   renderComponent(registration);
 
   screen.getByText(
-    'Ilmoittautuminen tähän tapahtumaan on tällä hetkellä suljettu. Kokeile myöhemmin uudelleen.'
+    'Tapahtuman kaikki paikat ovat tällä hetkellä varatut. Kokeile myöhemmin uudelleen.'
   );
+});
+
+test('should not show warning if registration is full but user has reservation', async () => {
+  const reservation = getMockedSeatsReservationData(1000);
+  setSessionStorageValues(reservation, registration);
+  renderComponent(registration);
+
+  expect(
+    screen.queryByText(
+      'Tapahtuman kaikki paikat ovat tällä hetkellä varatut. Kokeile myöhemmin uudelleen.'
+    )
+  ).not.toBeInTheDocument();
 });

--- a/src/domain/registration/__mocks__/registration.ts
+++ b/src/domain/registration/__mocks__/registration.ts
@@ -1,24 +1,12 @@
 import addDays from 'date-fns/addDays';
 import subDays from 'date-fns/subDays';
 
-import {
-  fakeEvent,
-  fakeRegistration,
-  fakeRegistrations,
-} from '../../../utils/mockDataUtils';
+import { fakeRegistration } from '../../../utils/mockDataUtils';
 import { event } from '../../event/__mocks__/event';
-import {
-  TEST_EVENT_ID,
-  TEST_EVENT_ID2,
-  TEST_EVENT_ID3,
-  TEST_EVENT_ID4,
-  TEST_EVENT_ID5,
-} from '../../event/constants';
 import {
   REGISTRATION_MANDATORY_FIELDS,
   TEST_REGISTRATION_ID,
 } from '../constants';
-import { Registration } from '../types';
 
 const now = new Date();
 const enrolment_start_time = subDays(now, 1).toISOString();
@@ -27,6 +15,8 @@ const registrationOverrides = {
   enrolment_end_time,
   enrolment_start_time,
   maximum_attendee_capacity: 10,
+  remaining_attendee_capacity: 10,
+  remaining_waiting_list_capacity: 10,
   waiting_list_capacity: 10,
 };
 
@@ -39,47 +29,4 @@ const registration = fakeRegistration({
   mandatory_fields: [REGISTRATION_MANDATORY_FIELDS.NAME],
 });
 
-const registrationsOverrides: Partial<Registration>[] = [
-  {
-    ...registrationOverrides,
-    id: '1',
-    event: fakeEvent({ id: TEST_EVENT_ID }),
-    current_attendee_count: 0,
-  },
-  {
-    ...registrationOverrides,
-    id: '2',
-    event: fakeEvent({ id: TEST_EVENT_ID2 }),
-    current_attendee_count: registrationOverrides.maximum_attendee_capacity,
-    current_waiting_list_count: 0,
-  },
-  {
-    ...registrationOverrides,
-    id: '3',
-    event: fakeEvent({ id: TEST_EVENT_ID3 }),
-    current_attendee_count: registrationOverrides.maximum_attendee_capacity,
-    current_waiting_list_count: 0,
-    waiting_list_capacity: null,
-  },
-  {
-    ...registrationOverrides,
-    id: '4',
-    event: fakeEvent({ id: TEST_EVENT_ID4 }),
-    current_attendee_count: registrationOverrides.maximum_attendee_capacity,
-    current_waiting_list_count: registrationOverrides.waiting_list_capacity,
-  },
-  {
-    ...registrationOverrides,
-    id: '5',
-    event: fakeEvent({ id: TEST_EVENT_ID5 }),
-    current_attendee_count: 1000,
-    maximum_attendee_capacity: 0,
-  },
-];
-
-const registrationsResponse = fakeRegistrations(
-  registrationsOverrides.length,
-  registrationsOverrides
-);
-
-export { registration, registrationsResponse };
+export { registration };

--- a/src/utils/mockDataUtils.ts
+++ b/src/utils/mockDataUtils.ts
@@ -284,8 +284,11 @@ export const fakeRegistration = (
       last_modified_by: '',
       mandatory_fields: [],
       maximum_attendee_capacity: null,
+      maximum_group_size: null,
       minimum_attendee_capacity: null,
       publisher: event.publisher,
+      remaining_attendee_capacity: null,
+      remaining_waiting_list_capacity: null,
       waiting_list_capacity: null,
     },
     overrides
@@ -295,15 +298,17 @@ export const fakeRegistration = (
 export const fakeSeatsReservation = (
   overrides?: Partial<SeatsReservation>
 ): SeatsReservation => {
+  const id = overrides?.id || faker.datatype.uuid();
+
   return merge<SeatsReservation, typeof overrides>(
     {
+      id,
       code: faker.datatype.uuid(),
       expiration: addMinutes(new Date(), 30).toISOString(),
+      in_waitlist: false,
       registration: TEST_REGISTRATION_ID,
       seats: 1,
       timestamp: new Date().toISOString(),
-      seats_at_event: 1,
-      waitlist_spots: 0,
     },
     overrides
   );
@@ -398,4 +403,18 @@ export const getMockedSeatsReservationData = (expirationOffset: number) => {
   const expiration = addSeconds(now, expirationOffset).toISOString();
 
   return fakeSeatsReservation({ expiration });
+};
+
+export const setSessionStorageValues = (
+  reservation: SeatsReservation,
+  registration: Registration
+) => {
+  jest.spyOn(sessionStorage, 'getItem').mockImplementation((key: string) => {
+    const reservationKey = `${RESERVATION_NAMES.ENROLMENT_RESERVATION}-${registration.id}`;
+
+    if (key === reservationKey) {
+      return reservation ? JSON.stringify(reservation) : '';
+    }
+    return '';
+  });
 };


### PR DESCRIPTION
## Description

- Enrolment is closed if enrolment_start_time is defined and is in the future or enrolment_end_time is defined and is in the past
- Show different warning message if enrolment is open but there is no available seats
- Add reserved seats to available seats amount if there is already reservation in the session storage
- Disable enrolment form also if there is no available places and seats reservation is not stored to session storage

PR for API implementation: https://github.com/City-of-Helsinki/linkedevents/pull/611
PR for Linked Components UI: https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/188

## Closes
[LINK-1363](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1363)


[LINK-1363]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ