### PR TITLE
LINK-1440 | Rename Privacy policy as Data protection notice

### DIFF
--- a/public/locales/en/enrolment.json
+++ b/public/locales/en/enrolment.json
@@ -44,7 +44,7 @@
     "tooltip": "Entrants have been added to the queue of registrants with a reserve place. Registration is confirmed only when a place in the queue becomes available. You will receive a notification by e-mail that the place has been confirmed."
   },
   "instructions": "Registration instructions",
-  "labelAccepted": "I agree to share my information with the organizer. We do not use the information you provide for marketing purposes. <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Privacy policy {{openInNewTab}}\">Privacy policy</a>",
+  "labelAccepted": "I agree to share my information with the organizer. We do not use the information you provide for marketing purposes. <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Data protection notice {{openInNewTab}}\">Data protection notice</a>",
   "labelAttendeeExtraInfo": "Additional information (optional)",
   "labelCity": "City",
   "labelDateOfBirth": "Date of birth",
@@ -59,7 +59,7 @@
   "labelServiceLanguage": "Language of communication",
   "labelStreetAddress": "Street address",
   "labelZipcode": "Postcode",
-  "linkPrivacyPolicy": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/Kayttajatunnusten%20hallinta.pdf",
+  "linkDataProtectionNotice": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/Kayttajatunnusten%20hallinta.pdf",
   "notifications": {
     "email": "By email",
     "sms": "By text message"

--- a/public/locales/fi/enrolment.json
+++ b/public/locales/fi/enrolment.json
@@ -44,7 +44,7 @@
     "text": "Varasija",
     "tooltip": "Ilmoittautuja on lisätty ilmoittautujien jonoon varasijalla. Ilmoittautuminen varmistuu vasta, kun paikka jonossa vapautuu. Saat paikan varmistumisesta ilmoituksen sähköpostitse."
   },
-  "labelAccepted": "Hyväksyn tietojeni jakamisen järjestäjän kanssa. Emme käytä antamiasi tietoja markkinointiin. <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Rekisteriseloste {{openInNewTab}}\">Rekisteriseloste</a>",
+  "labelAccepted": "Hyväksyn tietojeni jakamisen järjestäjän kanssa. Emme käytä antamiasi tietoja markkinointiin. <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Tietosuojaseloste {{openInNewTab}}\">Tietosuojaseloste</a>",
   "labelAttendeeExtraInfo": "Lisätietoa (valinnainen)",
   "labelCity": "Kaupunki",
   "labelDateOfBirth": "Syntymäaika",
@@ -59,7 +59,7 @@
   "labelServiceLanguage": "Asiointikieli",
   "labelStreetAddress": "Katuosoite",
   "labelZipcode": "Postinumero",
-  "linkPrivacyPolicy": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/Kayttajatunnusten%20hallinta.pdf",
+  "linkDataProtectionNotice": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/Kayttajatunnusten%20hallinta.pdf",
   "notifications": {
     "email": "Sähköpostilla",
     "sms": "Tekstiviestillä"

--- a/public/locales/sv/enrolment.json
+++ b/public/locales/sv/enrolment.json
@@ -44,7 +44,7 @@
     "text": "På väntelista",
     "tooltip": "Deltagare har lagts till i kön av anmälda med reservplats. Anmälan bekräftas först när en plats i kön blir ledig. Du får ett meddelande via e-post om att platsen är bekräftad."
   },
-  "labelAccepted": "Jag godkänner att dela min information med arrangören. Vi använder inte informationen du tillhandahåller för marknadsföringsändamål. <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Integritetspolicy {{openInNewTab}}\">Integritetspolicy</a>",
+  "labelAccepted": "Jag godkänner att dela min information med arrangören. Vi använder inte informationen du tillhandahåller för marknadsföringsändamål. <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Registerbeskrivningen {{openInNewTab}}\">Registerbeskrivningen</a>",
   "labelAttendeeExtraInfo": "Ytterligare information (valfritt)",
   "labelCity": "Staden",
   "labelDateOfBirth": "Födelsedatum",
@@ -59,7 +59,7 @@
   "labelServiceLanguage": "Transaktionsspråk",
   "labelStreetAddress": "Gatuadress",
   "labelZipcode": "Postnummer",
-  "linkPrivacyPolicy": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/Kayttajatunnusten%20hallinta.pdf",
+  "linkDataProtectionNotice": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/Kayttajatunnusten%20hallinta.pdf",
   "notifications": {
     "email": "Via e-post",
     "sms": "Med sms"

--- a/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
+++ b/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
@@ -356,7 +356,7 @@ const EnrolmentForm: React.FC<Props> = ({
                           dangerouslySetInnerHTML={{
                             __html: t('labelAccepted', {
                               openInNewTab: t('common:openInNewTab'),
-                              url: t('linkPrivacyPolicy'),
+                              url: t('linkDataProtectionNotice'),
                             }),
                           }}
                         />


### PR DESCRIPTION
## Description
Rename Privacy policy as Data protection notice

## Closes
[LINK-1440](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1440)

[LINK-1440]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ