### PR TITLE
LINK-1482 | Define domain for the cookie consent modal cookies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "i18next": "^22.0.6",
     "lodash": "^4.17.21",
     "next": "13.0.5",
-    "next-absolute-url": "^1.2.2",
     "next-auth": "^4.19.2",
     "next-i18next": "^13.0.0",
     "react": "18.2.0",

--- a/src/domain/app/cookieConsent/CookieConsent.tsx
+++ b/src/domain/app/cookieConsent/CookieConsent.tsx
@@ -9,7 +9,10 @@ import useSelectLanguage from '../../../hooks/useSelectLanguage';
 type SupportedLanguage = 'en' | 'fi' | 'sv';
 
 /* istanbul ignore next */
-const origin = typeof window !== 'undefined' ? window.location.origin : '';
+const hostname =
+  typeof window !== 'undefined'
+    ? window.location.hostname
+    : new URL(process.env.NEXTAUTH_URL as string).hostname;
 
 const CookieConsent: FC = () => {
   const { t } = useTranslation('common');
@@ -29,6 +32,7 @@ const CookieConsent: FC = () => {
 
   return (
     <CookieModal
+      cookieDomain={hostname}
       contentSource={{
         siteName: t('cookieConsent.siteName') as string,
         currentLanguage: locale,
@@ -43,7 +47,7 @@ const CookieConsent: FC = () => {
               cookies: [
                 {
                   id: 'enrolmentForm',
-                  hostName: origin,
+                  hostName: hostname,
                   name: t('cookieConsent.enrolmentForm.name') as string,
                   description: t(
                     'cookieConsent.enrolmentForm.description'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4988,11 +4988,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-next-absolute-url@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/next-absolute-url/-/next-absolute-url-1.2.2.tgz#9aba5adcee8effcffd63271d99e13213ad04c23b"
-  integrity sha512-Z2+LZXQTthhw2je9u4eq8QWXxXd57a6b54x9exBfQX4Dct6YxaMjcXZWNLHd9AOlCue84EsMpdSGP7wACqUnPg==
-
 next-auth@^4.19.2:
   version "4.19.2"
   resolved "https://registry.yarnpkg.com/next-auth/-/next-auth-4.19.2.tgz#8dbdc4886d4f006e7c67c77ab56e0aec5693064d"


### PR DESCRIPTION
## Description :sparkles:
Define domain for the cookie consent modal cookies. Reason for this is that https://www.hel.fi/fi clear all the cookies that it's not using. So visiting in that site also cleared cookies from Linked Registration UI

## Closes
[LINK-1482](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1482)

[LINK-1482]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ