### PR TITLE
LINK-1505 | Hide SMS notification options since it's not supported in API

### DIFF
--- a/src/domain/signupGroup/hooks/useNotificationOptions.ts
+++ b/src/domain/signupGroup/hooks/useNotificationOptions.ts
@@ -8,10 +8,13 @@ const useNotificationOptions = (): OptionType[] => {
   const { t } = useTranslation('signup');
   const options: OptionType[] = React.useMemo(
     () =>
-      Object.values(NOTIFICATIONS).map((type) => ({
-        label: t(`notifications.${type}`),
-        value: type,
-      })),
+      Object.values(NOTIFICATIONS)
+        // TODO: At the moment only email messages are supported in API. So hide SMS option
+        .filter((t) => t === NOTIFICATIONS.EMAIL)
+        .map((type) => ({
+          label: t(`notifications.${type}`),
+          value: type,
+        })),
     [t]
   );
 

--- a/src/domain/signupGroup/testUtils.ts
+++ b/src/domain/signupGroup/testUtils.ts
@@ -79,7 +79,6 @@ export const shouldRenderSignupFormFields = async () => {
   getSignupFormElement('emailInput');
   getSignupFormElement('phoneInput');
   getSignupFormElement('emailCheckbox');
-  getSignupFormElement('phoneCheckbox');
   getSignupFormElement('nativeLanguageButton');
   getSignupFormElement('serviceLanguageButton');
   getSignupFormElement('cancelButton');


### PR DESCRIPTION
## Description
Hide SMS notification options since it's not supported in API

## Closes
[LINK-1505](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1505)

## Screenshot
<img width="928" alt="Screenshot 2023-09-20 at 14 15 41" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/6dcb488d-2687-4ec0-aba3-3d1089e477ed">


[LINK-1505]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ