### PR TITLE
LINK-1450 | 1/4 Rename SignupFields type as SignupFormFields

### DIFF
--- a/src/domain/signup/hooks/useSeatsReservationActions.ts
+++ b/src/domain/signup/hooks/useSeatsReservationActions.ts
@@ -19,14 +19,14 @@ import {
   setSeatsReservationData,
 } from '../../reserveSeats/utils';
 import { useSignupGroupFormContext } from '../../signupGroup/signupGroupFormContext/hooks/useSignupGroupFormContext';
-import { SignupFields } from '../../signupGroup/types';
+import { SignupFormFields } from '../../signupGroup/types';
 import { getNewSignups } from '../../signupGroup/utils';
 import { SIGNUP_MODALS } from '../constants';
 
 type UseSeatsReservationActionsProps = {
   registration: Registration;
-  setSignups?: (value: SignupFields[]) => void;
-  signups?: SignupFields[];
+  setSignups?: (value: SignupFormFields[]) => void;
+  signups?: SignupFormFields[];
 };
 
 type UseSeatsReservationActionsState = {

--- a/src/domain/signup/utils.ts
+++ b/src/domain/signup/utils.ts
@@ -4,7 +4,7 @@ import { ExtendedSession } from '../../types';
 import formatDate from '../../utils/formatDate';
 import { callDelete, callGet } from '../app/axios/axiosClient';
 import { NOTIFICATIONS } from '../signupGroup/constants';
-import { SignupFields, SignupGroupFormFields } from '../signupGroup/types';
+import { SignupFormFields, SignupGroupFormFields } from '../signupGroup/types';
 
 import { ATTENDEE_STATUS } from './constants';
 import { Signup, SignupQueryVariables } from './types';
@@ -47,7 +47,7 @@ export const deleteSignup = async ({
   }
 };
 
-export const getSignupInitialValues = (signup: Signup): SignupFields => ({
+export const getSignupInitialValues = (signup: Signup): SignupFormFields => ({
   city: signup.city ?? '',
   dateOfBirth: signup.date_of_birth
     ? formatDate(new Date(signup.date_of_birth))

--- a/src/domain/signupGroup/__tests__/validation.test.ts
+++ b/src/domain/signupGroup/__tests__/validation.test.ts
@@ -6,7 +6,7 @@ import { fakeRegistration } from '../../../utils/mockDataUtils';
 import { REGISTRATION_MANDATORY_FIELDS } from '../../registration/constants';
 import { Registration } from '../../registration/types';
 import { NOTIFICATIONS } from '../constants';
-import { SignupFields, SignupGroupFormFields } from '../types';
+import { SignupFormFields, SignupGroupFormFields } from '../types';
 import {
   getSignupGroupSchema,
   getSignupSchema,
@@ -56,7 +56,7 @@ const testBelowMaxAge = async (maxAge: number, date: string) => {
 
 const testSignupSchema = async (
   registration: Registration,
-  signup: SignupFields
+  signup: SignupFormFields
 ) => {
   try {
     await getSignupSchema(registration).validate(signup);
@@ -132,7 +132,7 @@ describe('isBelowMaxAge function', () => {
 
 describe('signupSchema function', () => {
   const registration = fakeRegistration();
-  const validSignup: SignupFields = {
+  const validSignup: SignupFormFields = {
     city: 'City',
     dateOfBirth: '1.1.2000',
     extraInfo: '',

--- a/src/domain/signupGroup/constants.ts
+++ b/src/domain/signupGroup/constants.ts
@@ -1,4 +1,4 @@
-import { SignupFields, SignupGroupFormFields } from './types';
+import { SignupFormFields, SignupGroupFormFields } from './types';
 
 export enum SIGNUP_FIELDS {
   CITY = 'city',
@@ -30,7 +30,7 @@ export enum NOTIFICATIONS {
   SMS = 'sms',
 }
 
-export const SIGNUP_INITIAL_VALUES: SignupFields = {
+export const SIGNUP_INITIAL_VALUES: SignupFormFields = {
   [SIGNUP_FIELDS.CITY]: '',
   [SIGNUP_FIELDS.DATE_OF_BIRTH]: '',
   [SIGNUP_FIELDS.EXTRA_INFO]: '',

--- a/src/domain/signupGroup/participantAmountSelector/ParticipantAmountSelector.tsx
+++ b/src/domain/signupGroup/participantAmountSelector/ParticipantAmountSelector.tsx
@@ -15,7 +15,7 @@ import { SIGNUP_MODALS } from '../../signup/constants';
 import useSeatsReservationActions from '../../signup/hooks/useSeatsReservationActions';
 import { useSignupServerErrorsContext } from '../../signup/signupServerErrorsContext/hooks/useSignupServerErrorsContext';
 import { SIGNUP_GROUP_FIELDS } from '../../signupGroup/constants';
-import { SignupFields } from '../../signupGroup/types';
+import { SignupFormFields } from '../../signupGroup/types';
 import ConfirmDeleteSignupFromForm from '../modals/confirmDeleteSignupFromFormModal/ConfirmDeleteSignupFromFormModal';
 import { useSignupGroupFormContext } from '../signupGroupFormContext/hooks/useSignupGroupFormContext';
 
@@ -39,7 +39,7 @@ const ParticipantAmountSelector: React.FC<Props> = ({
   const [participantsToDelete, setParticipantsToDelete] = useState(0);
 
   const [{ value: signups }, , { setValue: setSignups }] = useField<
-    SignupFields[]
+    SignupFormFields[]
   >({ name: SIGNUP_GROUP_FIELDS.SIGNUPS });
 
   const [participantAmount, setParticipantAmount] = useState(

--- a/src/domain/signupGroup/reservationTimer/ReservationTimer.tsx
+++ b/src/domain/signupGroup/reservationTimer/ReservationTimer.tsx
@@ -19,7 +19,7 @@ import { useSignupServerErrorsContext } from '../../signup/signupServerErrorsCon
 import { clearCreateSignupGroupFormData } from '../../signupGroup/utils';
 import ReservationTimeExpiredModal from '../modals/reservationTimeExpiredModal/ReservationTimeExpiredModal';
 import { useSignupGroupFormContext } from '../signupGroupFormContext/hooks/useSignupGroupFormContext';
-import { SignupFields } from '../types';
+import { SignupFormFields } from '../types';
 
 const getTimeStr = (timeLeft: number) => {
   const hours = Math.floor(timeLeft / 3600);
@@ -40,8 +40,8 @@ interface ReservationTimerProps {
   initReservationData: boolean;
   onDataNotFound?: () => void;
   registration: Registration;
-  setSignups?: (value: SignupFields[]) => void;
-  signups?: SignupFields[];
+  setSignups?: (value: SignupFormFields[]) => void;
+  signups?: SignupFormFields[];
 }
 
 const ReservationTimer: React.FC<ReservationTimerProps> = ({

--- a/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
+++ b/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
@@ -47,7 +47,7 @@ import useSignupGroupActions from '../hooks/useSignupGroupActions';
 import ParticipantAmountSelector from '../participantAmountSelector/ParticipantAmountSelector';
 import ReservationTimer from '../reservationTimer/ReservationTimer';
 import { useSignupGroupFormContext } from '../signupGroupFormContext/hooks/useSignupGroupFormContext';
-import { SignupFields, SignupGroup, SignupGroupFormFields } from '../types';
+import { SignupFormFields, SignupGroup, SignupGroupFormFields } from '../types';
 import { isSignupFieldRequired } from '../utils';
 import {
   getSignupGroupSchema,
@@ -186,7 +186,7 @@ const SignupGroupForm: React.FC<Props> = ({
       {({ setErrors, setFieldValue, setTouched, values }) => {
         const clearErrors = () => setErrors({});
 
-        const setSignups = (signups: SignupFields[]) => {
+        const setSignups = (signups: SignupFormFields[]) => {
           setFieldValue(SIGNUP_GROUP_FIELDS.SIGNUPS, signups);
         };
 

--- a/src/domain/signupGroup/signupGroupForm/signups/Signups.tsx
+++ b/src/domain/signupGroup/signupGroupForm/signups/Signups.tsx
@@ -14,7 +14,7 @@ import {
 import { useSignupServerErrorsContext } from '../../../signup/signupServerErrorsContext/hooks/useSignupServerErrorsContext';
 import { SIGNUP_GROUP_FIELDS } from '../../constants';
 import ConfirmDeleteParticipantModal from '../../modals/confirmDeleteSignupFromFormModal/ConfirmDeleteSignupFromFormModal';
-import { SignupFields } from '../../types';
+import { SignupFormFields } from '../../types';
 import { getNewSignups } from '../../utils';
 
 import Signup from './signup/Signup';
@@ -40,7 +40,7 @@ const Signups: React.FC<Props> = ({ formDisabled, readOnly, registration }) => {
     useSignupServerErrorsContext();
 
   const [{ value: signups }, , { setValue: setSignups }] = useField<
-    SignupFields[]
+    SignupFormFields[]
   >({ name: SIGNUP_GROUP_FIELDS.SIGNUPS });
 
   const closeModal = () => {

--- a/src/domain/signupGroup/signupGroupForm/signups/signup/Signup.tsx
+++ b/src/domain/signupGroup/signupGroupForm/signups/signup/Signup.tsx
@@ -15,7 +15,7 @@ import { Registration } from '../../../../registration/types';
 import { READ_ONLY_PLACEHOLDER, SIGNUP_FIELDS } from '../../../constants';
 import InWaitingListInfo from '../../../inWaitingListInfo/InWaitingListInfo';
 import { useSignupGroupFormContext } from '../../../signupGroupFormContext/hooks/useSignupGroupFormContext';
-import { SignupFields } from '../../../types';
+import { SignupFormFields } from '../../../types';
 import {
   isDateOfBirthFieldRequired,
   isSignupFieldRequired,
@@ -30,7 +30,7 @@ type Props = {
   readOnly?: boolean;
   registration: Registration;
   showDelete: boolean;
-  signup: SignupFields;
+  signup: SignupFormFields;
   signupPath: string;
 };
 

--- a/src/domain/signupGroup/summaryPage/signups/Signups.tsx
+++ b/src/domain/signupGroup/summaryPage/signups/Signups.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'next-i18next';
 import React from 'react';
 
 import { SIGNUP_GROUP_FIELDS } from '../../constants';
-import { SignupFields } from '../../types';
+import { SignupFormFields } from '../../types';
 
 import Signup from './signup/Signup';
 import styles from './signups.module.scss';
@@ -14,7 +14,7 @@ const getSignupPath = (index: number) =>
 const Signups: React.FC = () => {
   const { t } = useTranslation('summary');
 
-  const [{ value: signups }] = useField<SignupFields[]>({
+  const [{ value: signups }] = useField<SignupFormFields[]>({
     name: SIGNUP_GROUP_FIELDS.SIGNUPS,
   });
 

--- a/src/domain/signupGroup/summaryPage/signups/signup/Signup.tsx
+++ b/src/domain/signupGroup/summaryPage/signups/signup/Signup.tsx
@@ -7,13 +7,13 @@ import TextArea from '../../../../../common/components/textArea/TextArea';
 import { SIGNUP_FIELDS } from '../../../constants';
 import Divider from '../../../divider/Divider';
 import InWaitingListInfo from '../../../inWaitingListInfo/InWaitingListInfo';
-import { SignupFields } from '../../../types';
+import { SignupFormFields } from '../../../types';
 import ReadOnlyTextInput from '../../readOnlyTextInput/ReadOnlyTextInput';
 
 import styles from './signup.module.scss';
 
 export type SignupProps = {
-  signup: SignupFields;
+  signup: SignupFormFields;
   signupPath: string;
 };
 

--- a/src/domain/signupGroup/types.ts
+++ b/src/domain/signupGroup/types.ts
@@ -28,7 +28,7 @@ export type SignupGroup = {
   signups: Signup[];
 };
 
-export type SignupFields = {
+export type SignupFormFields = {
   [SIGNUP_FIELDS.CITY]: string;
   [SIGNUP_FIELDS.DATE_OF_BIRTH]: string;
   [SIGNUP_FIELDS.EXTRA_INFO]: string;
@@ -50,7 +50,7 @@ export type SignupGroupFormFields = {
   [SIGNUP_GROUP_FIELDS.NOTIFICATIONS]: string[];
   [SIGNUP_GROUP_FIELDS.PHONE_NUMBER]: string;
   [SIGNUP_GROUP_FIELDS.SERVICE_LANGUAGE]: string;
-  [SIGNUP_GROUP_FIELDS.SIGNUPS]: SignupFields[];
+  [SIGNUP_GROUP_FIELDS.SIGNUPS]: SignupFormFields[];
 };
 
 export type DeleteSignupGroupMutationInput = {

--- a/src/domain/signupGroup/utils.ts
+++ b/src/domain/signupGroup/utils.ts
@@ -24,7 +24,7 @@ import {
 import {
   CreateSignupGroupMutationInput,
   CreateSignupGroupResponse,
-  SignupFields,
+  SignupFormFields,
   SignupGroup,
   SignupGroupFormFields,
   SignupGroupQueryVariables,
@@ -140,7 +140,7 @@ export const getSignupGroupPayload = ({
   };
 };
 
-export const getSignupDefaultInitialValues = (): SignupFields => ({
+export const getSignupDefaultInitialValues = (): SignupFormFields => ({
   ...SIGNUP_INITIAL_VALUES,
 });
 
@@ -192,7 +192,7 @@ export const getNewSignups = ({
   signups,
 }: {
   seatsReservation: SeatsReservation;
-  signups: SignupFields[];
+  signups: SignupFormFields[];
 }) => {
   const { in_waitlist, seats } = seatsReservation;
   const signupInitialValues = getSignupDefaultInitialValues();


### PR DESCRIPTION
## Description :sparkles:
Rename SignupFields type as SignupFormFields

This is the first of 4 PRs that will replace https://github.com/City-of-Helsinki/linkedregistrations-ui/pull/70
The original PR will be splitted to following parts:

- Renaming SignupFields type as SignupFormFields
- Fix typo in `isLoadingEventOrReigstration`. It should be `isLoadingEventOrRegistration`
- Page to see attendance list and mark presence status of signups
- Checking permission to see attendance list. User should has `is_strongly_identified=true` and registration should have `has_registration_user_access=true`

## Issues :bug:

## Partially closes
[LINK-1450](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1450)
