### PR TITLE
LINK-1484 | 3/5 Move delete signup button to the page bottom

### DIFF
--- a/public/locales/en/signup.json
+++ b/public/locales/en/signup.json
@@ -2,6 +2,7 @@
   "buttonCancel": "Cancel registration",
   "buttonDeleteSignup": "Delete participant",
   "buttonGoToSummary": "Continue to registration",
+  "buttonUpdate": "Save",
   "buttonUpdateParticipantAmount": "Update",
   "cancelledPage": {
     "text": "You have canceled your registration for our event {{name}}.",
@@ -64,6 +65,8 @@
     "email": "By email",
     "sms": "By text message"
   },
+  "notificationSignupUpdated": "The signup has been saved",
+  "notificationSignupGroupUpdated": "The signup group has been saved",
   "personsAddedToWaitingListModal": {
     "buttonClose": "Close",
     "text": "Please note that not all registrants' places are guaranteed. Entrants in the reserve position will only be confirmed if more places become available in the queue. You will receive a separate email from confirmed registration.",

--- a/public/locales/fi/signup.json
+++ b/public/locales/fi/signup.json
@@ -2,6 +2,7 @@
   "buttonCancel": "Peruuta ilmoittautuminen",
   "buttonDeleteSignup": "Poista osallistuja",
   "buttonGoToSummary": "Jatka ilmoittautumiseen",
+  "buttonUpdate": "Tallenna",
   "buttonUpdateParticipantAmount": "Päivitä",
   "cancelledPage": {
     "text": "Olet perunut ilmoittautumisesi tapahtumaamme {{name}}.",
@@ -64,6 +65,8 @@
     "email": "Sähköpostilla",
     "sms": "Tekstiviestillä"
   },
+  "notificationSignupUpdated": "Osallistujan tiedot on tallennettu",
+  "notificationSignupGroupUpdated": "Osallistujien tiedot on tallennettu",
   "personsAddedToWaitingListModal": {
     "buttonClose": "Sulje",
     "text": "Huomioi, että kaikki ilmoittautujien paikat eivät ole varmistettuja. Varasijalla olevat ilmoittautujat varmistuvat vain, jos jonosta vapautuu lisää paikkoja. Varmistuneesta ilmoittautumisesta saat erillisen sähköpostin.",

--- a/public/locales/sv/signup.json
+++ b/public/locales/sv/signup.json
@@ -2,6 +2,7 @@
   "buttonCancel": "Avbryt registreringen",
   "buttonDeleteSignup": "Ta bort deltagare",
   "buttonGoToSummary": "Fortsätt till registreringen",
+  "buttonUpdate": "Spara",
   "buttonUpdateParticipantAmount": "Uppdatera",
   "cancelledPage": {
     "text": "Du har avbokat din anmälan till vårt evenemang {{name}}.",
@@ -64,6 +65,8 @@
     "email": "Via e-post",
     "sms": "Med sms"
   },
+  "notificationSignupUpdated": "Deltagarinformation har sparad",
+  "notificationSignupGroupUpdated": "Deltagarinformation har sparad",
   "personsAddedToWaitingListModal": {
     "buttonClose": "Stänga",
     "text": "Observera att inte alla anmäldas platser är garanterade. Deltagare på reservplatsen bekräftas endast om fler platser blir lediga i kön. Du kommer att få ett separat e-postmeddelande från bekräftad registrering.",

--- a/src/domain/signup/EditSignupPage.tsx
+++ b/src/domain/signup/EditSignupPage.tsx
@@ -33,7 +33,7 @@ const EditSignupPage: React.FC<Props> = ({ event, registration, signup }) => {
       <SignupGroupForm
         event={event}
         initialValues={initialValues}
-        readOnly={true}
+        mode="update-signup"
         registration={registration}
         signup={signup}
       />

--- a/src/domain/signup/EditSignupPage.tsx
+++ b/src/domain/signup/EditSignupPage.tsx
@@ -3,15 +3,12 @@ import React from 'react';
 
 import LoadingSpinner from '../../common/components/loadingSpinner/LoadingSpinner';
 import { ExtendedSession } from '../../types';
-import Container from '../app/layout/container/Container';
 import MainContent from '../app/layout/mainContent/MainContent';
 import { Event } from '../event/types';
 import NotFound from '../notFound/NotFound';
 import useEventAndRegistrationData from '../registration/hooks/useEventAndRegistrationData';
 import { Registration } from '../registration/types';
 import SignInRequired from '../signInRequired/SignInRequired';
-import EventInfo from '../signupGroup/eventInfo/EventInfo';
-import FormContainer from '../signupGroup/formContainer/FormContainer';
 import SignupGroupForm from '../signupGroup/signupGroupForm/SignupGroupForm';
 import { SignupGroupFormProvider } from '../signupGroup/signupGroupFormContext/SignupGroupFormContext';
 
@@ -33,18 +30,13 @@ const EditSignupPage: React.FC<Props> = ({ event, registration, signup }) => {
   return (
     <MainContent>
       <SignupPageMeta event={event} />
-      <Container withOffset>
-        <FormContainer>
-          <EventInfo event={event} registration={registration} />
-
-          <SignupGroupForm
-            initialValues={initialValues}
-            readOnly={true}
-            registration={registration}
-            signup={signup}
-          />
-        </FormContainer>
-      </Container>
+      <SignupGroupForm
+        event={event}
+        initialValues={initialValues}
+        readOnly={true}
+        registration={registration}
+        signup={signup}
+      />
     </MainContent>
   );
 };

--- a/src/domain/signup/__mocks__/signup.ts
+++ b/src/domain/signup/__mocks__/signup.ts
@@ -1,8 +1,13 @@
+import subYears from 'date-fns/subYears';
+
+import formatDate from '../../../utils/formatDate';
 import { fakeSignup } from '../../../utils/mockDataUtils';
 import { TEST_SIGNUP_ID } from '../constants';
 
 const signup = fakeSignup({
   id: TEST_SIGNUP_ID,
+  date_of_birth: formatDate(subYears(new Date(), 15), 'yyyy-MM-dd'),
+  phone_number: '0441234567',
 });
 
 export { signup };

--- a/src/domain/signup/__tests__/EditSignupPage.test.tsx
+++ b/src/domain/signup/__tests__/EditSignupPage.test.tsx
@@ -6,6 +6,7 @@ import singletonRouter from 'next/router';
 import * as nextAuth from 'next-auth/react';
 import mockRouter from 'next-router-mock';
 import React from 'react';
+import { toast } from 'react-toastify';
 
 import { ExtendedSession } from '../../../types';
 import { fakeAuthenticatedSession } from '../../../utils/mockSession';
@@ -26,6 +27,7 @@ import {
   findFirstNameInput,
   shouldRenderSignupFormFields,
   tryToCancel,
+  tryToUpdate,
 } from '../../signupGroup/testUtils';
 import { signup } from '../__mocks__/signup';
 import { TEST_SIGNUP_ID } from '../constants';
@@ -110,6 +112,45 @@ test('should show error message when cancelling signup fails', async () => {
 
   await findFirstNameInput();
   await tryToCancel();
+
+  await screen.findByRole(
+    'heading',
+    { name: /lomakkeella on seuraavat virheet/i },
+    { timeout: 10000 }
+  );
+});
+
+test('should update signup', async () => {
+  toast.success = jest.fn();
+  setQueryMocks(
+    ...defaultMocks,
+    rest.put(`*/signup/${TEST_SIGNUP_ID}`, (req, res, ctx) =>
+      res(ctx.status(201), ctx.json(signup))
+    )
+  );
+  pushEditSignupRoute(TEST_REGISTRATION_ID);
+  renderComponent();
+
+  await findFirstNameInput();
+  await tryToUpdate();
+
+  await waitFor(() =>
+    expect(toast.success).toBeCalledWith('Osallistujan tiedot on tallennettu')
+  );
+});
+
+test('should show error message when updating signup fails', async () => {
+  setQueryMocks(
+    ...defaultMocks,
+    rest.put(`*/signup/${TEST_SIGNUP_ID}`, (req, res, ctx) =>
+      res(ctx.status(403), ctx.json({ name: 'Name is required.' }))
+    )
+  );
+  pushEditSignupRoute(TEST_REGISTRATION_ID);
+  renderComponent();
+
+  await findFirstNameInput();
+  await tryToUpdate();
 
   await screen.findByRole(
     'heading',

--- a/src/domain/signup/__tests__/mutation.test.ts
+++ b/src/domain/signup/__tests__/mutation.test.ts
@@ -1,0 +1,56 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { rest } from 'msw';
+
+import { fakeAuthenticatedSession } from '../../../utils/mockSession';
+import { getQueryWrapper, setQueryMocks } from '../../../utils/testUtils';
+import { TEST_REGISTRATION_ID } from '../../registration/constants';
+import { signup } from '../__mocks__/signup';
+import { TEST_SIGNUP_ID } from '../constants';
+import { useUpdateSignupMutation } from '../mutation';
+
+describe('useUpdateSignupMutation', () => {
+  it('should update signup successfully', async () => {
+    const wrapper = getQueryWrapper();
+    setQueryMocks(
+      rest.put(`*/signup/${TEST_SIGNUP_ID}/`, (req, res, ctx) =>
+        res(ctx.status(200), ctx.json(signup))
+      )
+    );
+    const { result } = renderHook(
+      () => useUpdateSignupMutation({ session: fakeAuthenticatedSession() }),
+      { wrapper }
+    );
+    result.current.mutate({
+      id: TEST_SIGNUP_ID,
+      responsible_for_group: true,
+      registration: TEST_REGISTRATION_ID,
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual(signup));
+  });
+
+  it('should get error when mutation fails', async () => {
+    // eslint-disable-next-line no-console
+    console.error = jest.fn();
+    const error = { errorMessage: 'Failed to update signup' };
+    const wrapper = getQueryWrapper();
+    setQueryMocks(
+      rest.put(`*/signup/${TEST_SIGNUP_ID}/`, (req, res, ctx) =>
+        res(ctx.status(404), ctx.json(error))
+      )
+    );
+    const { result } = renderHook(
+      () => useUpdateSignupMutation({ session: fakeAuthenticatedSession() }),
+      { wrapper }
+    );
+    result.current.mutate({
+      id: TEST_SIGNUP_ID,
+      responsible_for_group: true,
+      registration: TEST_REGISTRATION_ID,
+    });
+
+    await waitFor(() =>
+      expect(result.current.error).toEqual(new Error(JSON.stringify(error)))
+    );
+  });
+});

--- a/src/domain/signup/__tests__/utils.test.ts
+++ b/src/domain/signup/__tests__/utils.test.ts
@@ -1,9 +1,14 @@
 import { fakeSignup } from '../../../utils/mockDataUtils';
-import { NOTIFICATIONS } from '../../signupGroup/constants';
+import { registration } from '../../registration/__mocks__/registration';
+import {
+  NOTIFICATIONS,
+  SIGNUP_GROUP_INITIAL_VALUES,
+} from '../../signupGroup/constants';
 import { NOTIFICATION_TYPE, TEST_SIGNUP_ID } from '../constants';
 import { SignupQueryVariables } from '../types';
 import {
   getSignupGroupInitialValuesFromSignup,
+  getUpdateSignupPayload,
   signupPathBuilder,
 } from '../utils';
 
@@ -136,5 +141,96 @@ describe('getSignupGroupInitialValuesFromSignup function', () => {
     expect(notifications).toEqual(expectedNotifications);
     expect(phoneNumber).toBe(expectedPhoneNumber);
     expect(serviceLanguage).toBe(expectedServiceLanguage);
+  });
+});
+
+describe('getUpdateSignupPayload function', () => {
+  it('should return payload to update a signup', () => {
+    expect(
+      getUpdateSignupPayload({
+        formValues: SIGNUP_GROUP_INITIAL_VALUES,
+        id: TEST_SIGNUP_ID,
+        registration,
+      })
+    ).toEqual({
+      city: '',
+      date_of_birth: null,
+      email: null,
+      extra_info: '',
+      first_name: '',
+      id: TEST_SIGNUP_ID,
+      last_name: '',
+      membership_number: '',
+      native_language: null,
+      notifications: NOTIFICATION_TYPE.EMAIL,
+      phone_number: null,
+      registration: registration.id,
+      responsible_for_group: false,
+      service_language: null,
+      street_address: null,
+      zipcode: null,
+    });
+
+    const city = 'City',
+      dateOfBirth = '10.10.1999',
+      email = 'Email',
+      extraInfo = 'Extra info',
+      firstName = 'First name',
+      lastName = 'Last name',
+      membershipNumber = 'XXX-123',
+      nativeLanguage = 'fi',
+      notifications = [NOTIFICATIONS.EMAIL],
+      phoneNumber = '0441234567',
+      serviceLanguage = 'sv',
+      streetAddress = 'Street address',
+      zipcode = '00100';
+    const signups = [
+      {
+        city,
+        dateOfBirth,
+        extraInfo,
+        firstName,
+        id: null,
+        inWaitingList: false,
+        lastName,
+        responsibleForGroup: true,
+        streetAddress,
+        zipcode,
+      },
+    ];
+    const payload = getUpdateSignupPayload({
+      formValues: {
+        ...SIGNUP_GROUP_INITIAL_VALUES,
+        email,
+        extraInfo: '',
+        membershipNumber,
+        nativeLanguage,
+        notifications,
+        phoneNumber,
+        serviceLanguage,
+        signups,
+      },
+      id: TEST_SIGNUP_ID,
+      registration,
+    });
+
+    expect(payload).toEqual({
+      city,
+      date_of_birth: '1999-10-10',
+      email,
+      extra_info: extraInfo,
+      first_name: firstName,
+      id: TEST_SIGNUP_ID,
+      last_name: lastName,
+      membership_number: membershipNumber,
+      native_language: nativeLanguage,
+      notifications: NOTIFICATION_TYPE.EMAIL,
+      phone_number: phoneNumber,
+      registration: registration.id,
+      responsible_for_group: true,
+      service_language: serviceLanguage,
+      street_address: streetAddress,
+      zipcode,
+    });
   });
 });

--- a/src/domain/signup/constants.ts
+++ b/src/domain/signup/constants.ts
@@ -14,6 +14,7 @@ export const TEST_SIGNUP_ID = 'signup:1';
 
 export enum SIGNUP_ACTIONS {
   DELETE = 'delete',
+  UPDATE = 'update',
 }
 
 export enum SIGNUP_MODALS {

--- a/src/domain/signup/hooks/__tests__/useSignupActions.test.ts
+++ b/src/domain/signup/hooks/__tests__/useSignupActions.test.ts
@@ -1,0 +1,50 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { rest } from 'msw';
+
+import { getQueryWrapper, setQueryMocks } from '../../../../utils/testUtils';
+import { registration } from '../../../registration/__mocks__/registration';
+import { SIGNUP_GROUP_INITIAL_VALUES } from '../../../signupGroup/constants';
+import { signup } from '../../__mocks__/signup';
+import { TEST_SIGNUP_ID } from '../../constants';
+import useSignupAction from '../useSignupActions';
+
+describe('useSignupActions', () => {
+  it('should call onSuccess when updated successfully', async () => {
+    const onSuccess = jest.fn();
+    const wrapper = getQueryWrapper();
+    setQueryMocks(
+      rest.put(`*/signup/${TEST_SIGNUP_ID}/`, (req, res, ctx) =>
+        res(ctx.status(200), ctx.json(signup))
+      )
+    );
+    const { result } = renderHook(
+      () => useSignupAction({ registration, signup }),
+      { wrapper }
+    );
+    await act(() =>
+      result.current.updateSignup(SIGNUP_GROUP_INITIAL_VALUES, { onSuccess })
+    );
+
+    await waitFor(() => expect(onSuccess).toBeCalled());
+  });
+
+  it('should call onError when update fails', async () => {
+    // eslint-disable-next-line no-console
+    console.error = jest.fn();
+    const onError = jest.fn();
+    const error = { errorMessage: 'Failed to update signup' };
+    const wrapper = getQueryWrapper();
+    setQueryMocks(
+      rest.put(`*/signup/${TEST_SIGNUP_ID}/`, (req, res, ctx) =>
+        res(ctx.status(404), ctx.json(error))
+      )
+    );
+    const { result } = renderHook(
+      () => useSignupAction({ registration, signup }),
+      { wrapper }
+    );
+    await result.current.updateSignup(SIGNUP_GROUP_INITIAL_VALUES, { onError });
+
+    await waitFor(() => expect(onError).toBeCalled());
+  });
+});

--- a/src/domain/signup/modals/confirmDeleteSignupModal/ConfirmDeleteSignupModal.tsx
+++ b/src/domain/signup/modals/confirmDeleteSignupModal/ConfirmDeleteSignupModal.tsx
@@ -1,4 +1,4 @@
-import { Dialog, IconAlertCircle } from 'hds-react';
+import { Dialog, IconAlertCircle, IconCross } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 
@@ -7,14 +7,16 @@ import styles from '../../../../common/components/dialog/dialog.module.scss';
 
 export interface ConfirmDeleteSignupModalProps {
   isOpen: boolean;
+  isSaving: boolean;
   onClose: () => void;
-  onCancel: () => void;
+  onDelete: () => void;
 }
 
 const ConfirmDeleteSignupModal: React.FC<ConfirmDeleteSignupModalProps> = ({
   isOpen,
+  isSaving,
   onClose,
-  onCancel,
+  onDelete,
 }) => {
   const { t } = useTranslation(['signup', 'common']);
   const openConfirmationButtonRef = React.useRef(null);
@@ -44,7 +46,14 @@ const ConfirmDeleteSignupModal: React.FC<ConfirmDeleteSignupModalProps> = ({
         <p id={descriptionId}>{t('signup:deleteSignupModal.text')} </p>
       </Dialog.Content>
       <Dialog.ActionButtons>
-        <Button onClick={onCancel} variant="danger">
+        <Button
+          disabled={isSaving}
+          iconLeft={<IconCross aria-hidden={true} />}
+          isLoading={isSaving}
+          loadingText={t('signup:deleteSignupModal.buttonCancel') as string}
+          onClick={onDelete}
+          variant="danger"
+        >
           {t('signup:deleteSignupModal.buttonCancel')}
         </Button>
         <Button onClick={onClose} theme={'black'} variant="secondary">

--- a/src/domain/signup/modals/confirmDeleteSignupModal/__tests__/ConfirmDeleteSignupModal.test.tsx
+++ b/src/domain/signup/modals/confirmDeleteSignupModal/__tests__/ConfirmDeleteSignupModal.test.tsx
@@ -15,23 +15,24 @@ configure({ defaultHidden: true });
 
 const defaultProps: ConfirmDeleteSignupModalProps = {
   isOpen: true,
-  onCancel: jest.fn(),
+  isSaving: false,
   onClose: jest.fn(),
+  onDelete: jest.fn(),
 };
 
 const renderComponent = (props: Partial<ConfirmDeleteSignupModalProps>) =>
   render(<ConfirmDeleteSignupModal {...defaultProps} {...props} />);
 
-test('should call onCancel', async () => {
-  const onCancel = jest.fn();
+test('should call onDelete', async () => {
+  const onDelete = jest.fn();
   const user = userEvent.setup();
-  renderComponent({ onCancel });
+  renderComponent({ onDelete });
 
   const cancelButton = screen.getByRole('button', {
     name: 'Peruuta ilmoittautuminen',
   });
   await act(async () => await user.click(cancelButton));
-  expect(onCancel).toBeCalled();
+  expect(onDelete).toBeCalled();
 });
 
 test('should call onClose', async () => {

--- a/src/domain/signup/mutation.ts
+++ b/src/domain/signup/mutation.ts
@@ -6,8 +6,12 @@ import {
 
 import { ExtendedSession } from '../../types';
 
-import { DeleteSignupMutationInput } from './types';
-import { deleteSignup } from './utils';
+import {
+  DeleteSignupMutationInput,
+  Signup,
+  UpdateSignupMutationInput,
+} from './types';
+import { deleteSignup, updateSignup } from './utils';
 
 export const useDeleteSignupMutation = ({
   options,
@@ -20,6 +24,23 @@ export const useDeleteSignupMutation = ({
     ({ signupId }) =>
       deleteSignup({
         id: signupId,
+        session,
+      }),
+    options
+  );
+};
+
+export const useUpdateSignupMutation = ({
+  options,
+  session,
+}: {
+  options?: UseMutationOptions<Signup, Error, UpdateSignupMutationInput>;
+  session: ExtendedSession | null;
+}): UseMutationResult<Signup, Error, UpdateSignupMutationInput> => {
+  return useMutation(
+    (input) =>
+      updateSignup({
+        input,
         session,
       }),
     options

--- a/src/domain/signup/types.ts
+++ b/src/domain/signup/types.ts
@@ -8,6 +8,7 @@ export type SignupInput = {
   email?: stringOrNull;
   extra_info?: stringOrNull;
   first_name?: stringOrNull;
+  id?: stringOrNull;
   last_name?: stringOrNull;
   membership_number?: stringOrNull;
   native_language?: stringOrNull;
@@ -18,6 +19,11 @@ export type SignupInput = {
   street_address?: stringOrNull;
   zipcode?: stringOrNull;
 };
+
+export type UpdateSignupMutationInput = {
+  id: string;
+  registration: string;
+} & SignupInput;
 
 export type Signup = {
   id: string;

--- a/src/domain/signup/utils.ts
+++ b/src/domain/signup/utils.ts
@@ -65,7 +65,7 @@ export const updateSignup = async ({
     const { data } = await callPut({
       data: JSON.stringify(input),
       session,
-      url: signupPathBuilder({ id: id as string }),
+      url: signupPathBuilder({ id }),
     });
     return data;
   } catch (error) {

--- a/src/domain/signupGroup/CreateSignupGroupPage.tsx
+++ b/src/domain/signupGroup/CreateSignupGroupPage.tsx
@@ -35,18 +35,22 @@ const CreateSignupGroupPage: React.FC<Props> = ({ event, registration }) => {
   return (
     <MainContent>
       <SignupPageMeta event={event} />
-      <Container withOffset>
-        <FormContainer>
-          {!session && <AuthenticationRequiredNotification />}
-          <EventInfo event={event} registration={registration} />
-          {session && (
-            <SignupGroupForm
-              initialValues={initialValues}
-              registration={registration}
-            />
-          )}
-        </FormContainer>
-      </Container>
+      {!session && (
+        <Container withOffset>
+          <FormContainer>
+            {<AuthenticationRequiredNotification />}
+            <EventInfo event={event} registration={registration} />
+          </FormContainer>
+        </Container>
+      )}
+
+      {session && (
+        <SignupGroupForm
+          event={event}
+          initialValues={initialValues}
+          registration={registration}
+        />
+      )}
     </MainContent>
   );
 };

--- a/src/domain/signupGroup/CreateSignupGroupPage.tsx
+++ b/src/domain/signupGroup/CreateSignupGroupPage.tsx
@@ -48,6 +48,7 @@ const CreateSignupGroupPage: React.FC<Props> = ({ event, registration }) => {
         <SignupGroupForm
           event={event}
           initialValues={initialValues}
+          mode="create-signup-group"
           registration={registration}
         />
       )}

--- a/src/domain/signupGroup/EditSignupGroupPage.tsx
+++ b/src/domain/signupGroup/EditSignupGroupPage.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 import LoadingSpinner from '../../common/components/loadingSpinner/LoadingSpinner';
 import { ExtendedSession } from '../../types';
-import Container from '../app/layout/container/Container';
 import MainContent from '../app/layout/mainContent/MainContent';
 import { Event } from '../event/types';
 import NotFound from '../notFound/NotFound';
@@ -12,8 +11,6 @@ import { Registration } from '../registration/types';
 import SignInRequired from '../signInRequired/SignInRequired';
 import SignupPageMeta from '../signup/signupPageMeta/SignupPageMeta';
 import { SignupServerErrorsProvider } from '../signup/signupServerErrorsContext/SignupServerErrorsContext';
-import EventInfo from '../signupGroup/eventInfo/EventInfo';
-import FormContainer from '../signupGroup/formContainer/FormContainer';
 import SignupGroupForm from '../signupGroup/signupGroupForm/SignupGroupForm';
 import { SignupGroupFormProvider } from '../signupGroup/signupGroupFormContext/SignupGroupFormContext';
 import { getSignupGroupInitialValues } from '../signupGroup/utils';
@@ -37,18 +34,13 @@ const EditSignupGroupPage: React.FC<Props> = ({
   return (
     <MainContent>
       <SignupPageMeta event={event} />
-      <Container withOffset>
-        <FormContainer>
-          <EventInfo event={event} registration={registration} />
-
-          <SignupGroupForm
-            initialValues={initialValues}
-            readOnly={true}
-            registration={registration}
-            signupGroup={signupGroup}
-          />
-        </FormContainer>
-      </Container>
+      <SignupGroupForm
+        event={event}
+        initialValues={initialValues}
+        readOnly={true}
+        registration={registration}
+        signupGroup={signupGroup}
+      />
     </MainContent>
   );
 };

--- a/src/domain/signupGroup/EditSignupGroupPage.tsx
+++ b/src/domain/signupGroup/EditSignupGroupPage.tsx
@@ -37,7 +37,7 @@ const EditSignupGroupPage: React.FC<Props> = ({
       <SignupGroupForm
         event={event}
         initialValues={initialValues}
-        readOnly={true}
+        mode="update-signup-group"
         registration={registration}
         signupGroup={signupGroup}
       />

--- a/src/domain/signupGroup/__mocks__/signupGroup.ts
+++ b/src/domain/signupGroup/__mocks__/signupGroup.ts
@@ -1,10 +1,11 @@
-import { fakeSignup, fakeSignupGroup } from '../../../utils/mockDataUtils';
-import { TEST_SIGNUP_ID } from '../../signup/constants';
+import { fakeSignupGroup } from '../../../utils/mockDataUtils';
+import { signup } from '../../signup/__mocks__/signup';
 import { TEST_SIGNUP_GROUP_ID } from '../constants';
 
 const signupGroup = fakeSignupGroup({
   id: TEST_SIGNUP_GROUP_ID,
-  signups: [fakeSignup({ id: TEST_SIGNUP_ID })],
+
+  signups: [signup],
 });
 
 export { signupGroup };

--- a/src/domain/signupGroup/__tests__/mutation.test.ts
+++ b/src/domain/signupGroup/__tests__/mutation.test.ts
@@ -1,0 +1,61 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { rest } from 'msw';
+
+import { fakeAuthenticatedSession } from '../../../utils/mockSession';
+import { getQueryWrapper, setQueryMocks } from '../../../utils/testUtils';
+import { TEST_REGISTRATION_ID } from '../../registration/constants';
+import { signupGroup } from '../__mocks__/signupGroup';
+import { TEST_SIGNUP_GROUP_ID } from '../constants';
+import { useUpdateSignupGroupMutation } from '../mutation';
+
+describe('useUpdateSignupGroupMutation', () => {
+  it('should update signup successfully', async () => {
+    const wrapper = getQueryWrapper();
+    setQueryMocks(
+      rest.put(`*/signup_group/${TEST_SIGNUP_GROUP_ID}/`, (req, res, ctx) =>
+        res(ctx.status(200), ctx.json(signupGroup))
+      )
+    );
+    const { result } = renderHook(
+      () =>
+        useUpdateSignupGroupMutation({ session: fakeAuthenticatedSession() }),
+      { wrapper }
+    );
+    result.current.mutate({
+      extra_info: '',
+      id: TEST_SIGNUP_GROUP_ID,
+      registration: TEST_REGISTRATION_ID,
+      signups: [],
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual(signupGroup));
+  });
+
+  it('should get error when mutation fails', async () => {
+    // eslint-disable-next-line no-console
+    console.error = jest.fn();
+    const error = { errorMessage: 'Failed to update signup' };
+    const wrapper = getQueryWrapper();
+    setQueryMocks(
+      rest.put(`*/signup_group/${TEST_SIGNUP_GROUP_ID}/`, (req, res, ctx) =>
+        res(ctx.status(404), ctx.json(error))
+      )
+    );
+
+    const { result } = renderHook(
+      () =>
+        useUpdateSignupGroupMutation({ session: fakeAuthenticatedSession() }),
+      { wrapper }
+    );
+    result.current.mutate({
+      extra_info: '',
+      id: TEST_SIGNUP_GROUP_ID,
+      registration: TEST_REGISTRATION_ID,
+      signups: [],
+    });
+
+    await waitFor(() =>
+      expect(result.current.error).toEqual(new Error(JSON.stringify(error)))
+    );
+  });
+});

--- a/src/domain/signupGroup/__tests__/utils.test.ts
+++ b/src/domain/signupGroup/__tests__/utils.test.ts
@@ -4,13 +4,17 @@ import {
   fakeSignupGroup,
 } from '../../../utils/mockDataUtils';
 import { registration } from '../../registration/__mocks__/registration';
-import { REGISTRATION_MANDATORY_FIELDS } from '../../registration/constants';
+import {
+  REGISTRATION_MANDATORY_FIELDS,
+  TEST_REGISTRATION_ID,
+} from '../../registration/constants';
 import { NOTIFICATION_TYPE, TEST_SIGNUP_ID } from '../../signup/constants';
 import {
   NOTIFICATIONS,
   SIGNUP_GROUP_FIELDS,
   SIGNUP_GROUP_INITIAL_VALUES,
   SIGNUP_INITIAL_VALUES,
+  TEST_SIGNUP_GROUP_ID,
 } from '../constants';
 import { SignupGroupQueryVariables } from '../types';
 import {
@@ -20,6 +24,7 @@ import {
   getSignupGroupPayload,
   getSignupNotificationTypes,
   getSignupNotificationsCode,
+  getUpdateSignupGroupPayload,
   isSignupFieldRequired,
   signupGroupPathBuilder,
 } from '../utils';
@@ -420,4 +425,114 @@ describe('signupGroupPathBuilder function', () => {
   it.each(cases)('should build correct path', (variables, expectedPath) =>
     expect(signupGroupPathBuilder(variables)).toBe(expectedPath)
   );
+});
+
+describe('getUpdateSignupGroupPayload function', () => {
+  it('should return signup group payload default values', () => {
+    expect(
+      getUpdateSignupGroupPayload({
+        formValues: {
+          ...SIGNUP_GROUP_INITIAL_VALUES,
+          signups: [{ ...SIGNUP_INITIAL_VALUES }],
+        },
+        id: TEST_SIGNUP_GROUP_ID,
+        registration,
+      })
+    ).toEqual({
+      extra_info: '',
+      id: TEST_SIGNUP_GROUP_ID,
+      registration: TEST_REGISTRATION_ID,
+      signups: [
+        {
+          city: '',
+          date_of_birth: null,
+          email: null,
+          extra_info: '',
+          first_name: '',
+          id: undefined,
+          last_name: '',
+          membership_number: '',
+          native_language: null,
+          notifications: NOTIFICATION_TYPE.EMAIL,
+          phone_number: null,
+          responsible_for_group: false,
+          service_language: null,
+          street_address: null,
+          zipcode: null,
+        },
+      ],
+    });
+  });
+
+  it('should return signup group payload', () => {
+    const city = 'City',
+      dateOfBirth = '10.10.1999',
+      email = 'Email',
+      extraInfo = 'Extra info',
+      groupExtraInfo = 'Group extra info',
+      firstName = 'First name',
+      lastName = 'Last name',
+      membershipNumber = 'XXX-123',
+      nativeLanguage = 'fi',
+      notifications = [NOTIFICATIONS.EMAIL],
+      phoneNumber = '0441234567',
+      serviceLanguage = 'sv',
+      streetAddress = 'Street address',
+      zipcode = '00100';
+    const signups = [
+      {
+        city,
+        dateOfBirth,
+        extraInfo,
+        firstName,
+        id: TEST_SIGNUP_ID,
+        inWaitingList: false,
+        lastName,
+        responsibleForGroup: true,
+        streetAddress,
+        zipcode,
+      },
+    ];
+
+    const payload = getUpdateSignupGroupPayload({
+      formValues: {
+        ...SIGNUP_GROUP_INITIAL_VALUES,
+        email,
+        extraInfo: groupExtraInfo,
+        membershipNumber,
+        nativeLanguage,
+        notifications,
+        phoneNumber,
+        serviceLanguage,
+        signups,
+      },
+      id: TEST_SIGNUP_GROUP_ID,
+      registration,
+    });
+
+    expect(payload).toEqual({
+      extra_info: groupExtraInfo,
+      id: TEST_SIGNUP_GROUP_ID,
+      registration: TEST_REGISTRATION_ID,
+      signups: [
+        {
+          city,
+          date_of_birth: '1999-10-10',
+          email,
+          extra_info: extraInfo,
+          first_name: firstName,
+          id: TEST_SIGNUP_ID,
+          last_name: lastName,
+          membership_number: membershipNumber,
+          native_language: nativeLanguage,
+          notifications: NOTIFICATION_TYPE.EMAIL,
+          phone_number: phoneNumber,
+          responsible_for_group: true,
+          service_language: serviceLanguage,
+          street_address: streetAddress,
+          zipcode,
+        },
+      ],
+    });
+  });
 });

--- a/src/domain/signupGroup/constants.ts
+++ b/src/domain/signupGroup/constants.ts
@@ -66,6 +66,4 @@ export enum SIGNUP_GROUP_ACTIONS {
   UPDATE = 'update',
 }
 
-export const READ_ONLY_PLACEHOLDER = '-';
-
 export const TEST_SIGNUP_GROUP_ID = 'signupGroup:1';

--- a/src/domain/signupGroup/constants.ts
+++ b/src/domain/signupGroup/constants.ts
@@ -63,6 +63,7 @@ export const SIGNUP_GROUP_FORM_SELECT_FIELDS = [
 export enum SIGNUP_GROUP_ACTIONS {
   CREATE = 'create',
   DELETE = 'delete',
+  UPDATE = 'update',
 }
 
 export const READ_ONLY_PLACEHOLDER = '-';

--- a/src/domain/signupGroup/editButtonPanel/EditButtonPanel.tsx
+++ b/src/domain/signupGroup/editButtonPanel/EditButtonPanel.tsx
@@ -1,0 +1,33 @@
+import { Button, IconCross } from 'hds-react';
+import { useTranslation } from 'next-i18next';
+
+import ButtonPanel from '../../../common/components/buttonPanel/ButtonPanel';
+
+type EditButtonPanelProps = {
+  disabled: boolean;
+  onDelete: () => void;
+};
+
+const EditButtonPanel: React.FC<EditButtonPanelProps> = ({
+  disabled,
+  onDelete,
+}) => {
+  const { t } = useTranslation('signup');
+  return (
+    <ButtonPanel
+      submitButtons={[
+        <Button
+          key="cancel"
+          disabled={disabled}
+          iconLeft={<IconCross aria-hidden={true} />}
+          onClick={onDelete}
+          variant="danger"
+        >
+          {t('buttonCancel')}
+        </Button>,
+      ]}
+    ></ButtonPanel>
+  );
+};
+
+export default EditButtonPanel;

--- a/src/domain/signupGroup/editButtonPanel/EditButtonPanel.tsx
+++ b/src/domain/signupGroup/editButtonPanel/EditButtonPanel.tsx
@@ -1,16 +1,24 @@
-import { Button, IconCross } from 'hds-react';
+import { Button, IconCross, IconPen } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 
 import ButtonPanel from '../../../common/components/buttonPanel/ButtonPanel';
+import { SIGNUP_ACTIONS } from '../../signup/constants';
+import { SIGNUP_GROUP_ACTIONS } from '../constants';
 
 type EditButtonPanelProps = {
   disabled: boolean;
-  onDelete: () => void;
+  onCancel: () => void;
+  onUpdate: () => void;
+  savingSignup: SIGNUP_ACTIONS | null;
+  savingSignupGroup: SIGNUP_GROUP_ACTIONS | null;
 };
 
 const EditButtonPanel: React.FC<EditButtonPanelProps> = ({
   disabled,
-  onDelete,
+  onCancel,
+  onUpdate,
+  savingSignup,
+  savingSignupGroup,
 }) => {
   const { t } = useTranslation('signup');
   return (
@@ -18,12 +26,30 @@ const EditButtonPanel: React.FC<EditButtonPanelProps> = ({
       submitButtons={[
         <Button
           key="cancel"
-          disabled={disabled}
           iconLeft={<IconCross aria-hidden={true} />}
-          onClick={onDelete}
+          onClick={onCancel}
           variant="danger"
         >
           {t('buttonCancel')}
+        </Button>,
+
+        <Button
+          key="update"
+          disabled={Boolean(
+            disabled ||
+              savingSignup === SIGNUP_ACTIONS.UPDATE ||
+              savingSignupGroup === SIGNUP_GROUP_ACTIONS.UPDATE
+          )}
+          iconLeft={<IconPen aria-hidden={true} />}
+          isLoading={
+            savingSignup === SIGNUP_ACTIONS.UPDATE ||
+            savingSignupGroup === SIGNUP_GROUP_ACTIONS.UPDATE
+          }
+          loadingText={t('buttonUpdate') as string}
+          onClick={onUpdate}
+          variant="primary"
+        >
+          {t('buttonUpdate')}
         </Button>,
       ]}
     ></ButtonPanel>

--- a/src/domain/signupGroup/hooks/__tests__/useSignupGroupActions.test.ts
+++ b/src/domain/signupGroup/hooks/__tests__/useSignupGroupActions.test.ts
@@ -1,0 +1,56 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { rest } from 'msw';
+
+import { getQueryWrapper, setQueryMocks } from '../../../../utils/testUtils';
+import { registration } from '../../../registration/__mocks__/registration';
+import { signupGroup } from '../../__mocks__/signupGroup';
+import {
+  SIGNUP_GROUP_INITIAL_VALUES,
+  TEST_SIGNUP_GROUP_ID,
+} from '../../constants';
+import useSignupGroupAction from '../useSignupGroupActions';
+
+describe('useSignupGroupActions', () => {
+  it('should call onSuccess when updated successfully', async () => {
+    const onSuccess = jest.fn();
+    const wrapper = getQueryWrapper();
+    setQueryMocks(
+      rest.put(`*/signup_group/${TEST_SIGNUP_GROUP_ID}/`, (req, res, ctx) =>
+        res(ctx.status(200), ctx.json(signupGroup))
+      )
+    );
+    const { result } = renderHook(
+      () => useSignupGroupAction({ registration, signupGroup }),
+      { wrapper }
+    );
+    await act(() =>
+      result.current.updateSignupGroup(SIGNUP_GROUP_INITIAL_VALUES, {
+        onSuccess,
+      })
+    );
+
+    await waitFor(() => expect(onSuccess).toBeCalled());
+  });
+
+  it('should call onError when update fails', async () => {
+    // eslint-disable-next-line no-console
+    console.error = jest.fn();
+    const onError = jest.fn();
+    const error = { errorMessage: 'Failed to update signup' };
+    const wrapper = getQueryWrapper();
+    setQueryMocks(
+      rest.put(`*/signup_group/${TEST_SIGNUP_GROUP_ID}/`, (req, res, ctx) =>
+        res(ctx.status(404), ctx.json(error))
+      )
+    );
+    const { result } = renderHook(
+      () => useSignupGroupAction({ registration, signupGroup }),
+      { wrapper }
+    );
+    await result.current.updateSignupGroup(SIGNUP_GROUP_INITIAL_VALUES, {
+      onError,
+    });
+
+    await waitFor(() => expect(onError).toBeCalled());
+  });
+});

--- a/src/domain/signupGroup/hooks/useSignupGroupActions.ts
+++ b/src/domain/signupGroup/hooks/useSignupGroupActions.ts
@@ -3,33 +3,45 @@ import { useSession } from 'next-auth/react';
 import useHandleError from '../../../hooks/useHandleError';
 import useMountedState from '../../../hooks/useMountedState';
 import { ExtendedSession, MutationCallbacks } from '../../../types';
+import { Registration } from '../../registration/types';
+import { getSeatsReservationData } from '../../reserveSeats/utils';
 import { SIGNUP_GROUP_ACTIONS } from '../constants';
 import {
   useCreateSignupGroupMutation,
   useDeleteSignupGroupMutation,
+  useUpdateSignupGroupMutation,
 } from '../mutation';
 import { useSignupGroupFormContext } from '../signupGroupFormContext/hooks/useSignupGroupFormContext';
 import {
   CreateSignupGroupMutationInput,
   DeleteSignupGroupMutationInput,
   SignupGroup,
+  SignupGroupFormFields,
+  UpdateSignupGroupMutationInput,
 } from '../types';
+import { getSignupGroupPayload, getUpdateSignupGroupPayload } from '../utils';
 
 interface Props {
+  registration: Registration;
   signupGroup?: SignupGroup;
 }
 
 type UseSignupActionsState = {
   createSignupGroup: (
-    payload: CreateSignupGroupMutationInput,
+    values: SignupGroupFormFields,
     callbacks?: MutationCallbacks
   ) => Promise<void>;
   deleteSignupGroup: (callbacks?: MutationCallbacks) => Promise<void>;
   saving: SIGNUP_GROUP_ACTIONS | null;
+  updateSignupGroup: (
+    values: SignupGroupFormFields,
+    callbacks?: MutationCallbacks
+  ) => Promise<void>;
 };
 const useSignupGroupActions = ({
+  registration,
   signupGroup,
-}: Props = {}): UseSignupActionsState => {
+}: Props): UseSignupActionsState => {
   const { data: session } = useSession() as { data: ExtendedSession | null };
   const [saving, setSaving] = useMountedState<SIGNUP_GROUP_ACTIONS | null>(
     null
@@ -52,18 +64,28 @@ const useSignupGroupActions = ({
     SignupGroup
   >();
 
+  const createSignupGroupMutation = useCreateSignupGroupMutation({
+    session,
+  });
   const deleteSignupGroupMutation = useDeleteSignupGroupMutation({
     session,
   });
-  const createSignupGroupMutation = useCreateSignupGroupMutation({
+  const updateSignupGroupMutation = useUpdateSignupGroupMutation({
     session,
   });
 
   const createSignupGroup = async (
-    payload: CreateSignupGroupMutationInput,
+    values: SignupGroupFormFields,
     callbacks?: MutationCallbacks
   ) => {
     setSaving(SIGNUP_GROUP_ACTIONS.CREATE);
+    const reservationData = getSeatsReservationData(registration.id);
+    const payload = getSignupGroupPayload({
+      formValues: values,
+      registration,
+      reservationCode: reservationData?.code as string,
+    });
+
     createSignupGroupMutation.mutate(payload, {
       onError: (error, variables) => {
         handleError({
@@ -105,10 +127,41 @@ const useSignupGroupActions = ({
     );
   };
 
+  const updateSignupGroup = async (
+    values: SignupGroupFormFields,
+    callbacks?: MutationCallbacks
+  ) => {
+    setSaving(SIGNUP_GROUP_ACTIONS.UPDATE);
+    const payload: UpdateSignupGroupMutationInput = getUpdateSignupGroupPayload(
+      {
+        formValues: values,
+        id: signupGroup?.id as string,
+        registration: registration,
+      }
+    );
+
+    updateSignupGroupMutation.mutate(payload, {
+      onError: (error, variables) => {
+        handleError({
+          callbacks,
+          error,
+          message: 'Failed to update signup group',
+          object: signupGroup,
+          payload: variables,
+          savingFinished,
+        });
+      },
+      onSuccess: () => {
+        cleanAfterUpdate(callbacks);
+      },
+    });
+  };
+
   return {
     createSignupGroup,
     deleteSignupGroup,
     saving,
+    updateSignupGroup,
   };
 };
 

--- a/src/domain/signupGroup/mutation.ts
+++ b/src/domain/signupGroup/mutation.ts
@@ -8,10 +8,9 @@ import { ExtendedSession } from '../../types';
 
 import {
   CreateSignupGroupMutationInput,
-  CreateSignupGroupResponse,
+  CreateOrUpdateSignupGroupResponse,
   DeleteSignupGroupMutationInput,
   UpdateSignupGroupMutationInput,
-  UpdateSignupGroupResponse,
 } from './types';
 import {
   createSignupGroup,
@@ -24,13 +23,13 @@ export const useCreateSignupGroupMutation = ({
   session,
 }: {
   options?: UseMutationOptions<
-    CreateSignupGroupResponse,
+    CreateOrUpdateSignupGroupResponse,
     Error,
     CreateSignupGroupMutationInput
   >;
   session: ExtendedSession | null;
 }): UseMutationResult<
-  CreateSignupGroupResponse,
+  CreateOrUpdateSignupGroupResponse,
   Error,
   CreateSignupGroupMutationInput
 > => {
@@ -59,13 +58,13 @@ export const useUpdateSignupGroupMutation = ({
   session,
 }: {
   options?: UseMutationOptions<
-    UpdateSignupGroupResponse,
+    CreateOrUpdateSignupGroupResponse,
     Error,
     UpdateSignupGroupMutationInput
   >;
   session: ExtendedSession | null;
 }): UseMutationResult<
-  UpdateSignupGroupResponse,
+  CreateOrUpdateSignupGroupResponse,
   Error,
   UpdateSignupGroupMutationInput
 > => {

--- a/src/domain/signupGroup/mutation.ts
+++ b/src/domain/signupGroup/mutation.ts
@@ -10,8 +10,14 @@ import {
   CreateSignupGroupMutationInput,
   CreateSignupGroupResponse,
   DeleteSignupGroupMutationInput,
+  UpdateSignupGroupMutationInput,
+  UpdateSignupGroupResponse,
 } from './types';
-import { createSignupGroup, deleteSignupGroup } from './utils';
+import {
+  createSignupGroup,
+  deleteSignupGroup,
+  updateSignupGroup,
+} from './utils';
 
 export const useCreateSignupGroupMutation = ({
   options,
@@ -42,6 +48,31 @@ export const useDeleteSignupGroupMutation = ({
     ({ id }) =>
       deleteSignupGroup({
         id,
+        session,
+      }),
+    options
+  );
+};
+
+export const useUpdateSignupGroupMutation = ({
+  options,
+  session,
+}: {
+  options?: UseMutationOptions<
+    UpdateSignupGroupResponse,
+    Error,
+    UpdateSignupGroupMutationInput
+  >;
+  session: ExtendedSession | null;
+}): UseMutationResult<
+  UpdateSignupGroupResponse,
+  Error,
+  UpdateSignupGroupMutationInput
+> => {
+  return useMutation(
+    (input) =>
+      updateSignupGroup({
+        input,
         session,
       }),
     options

--- a/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
+++ b/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
@@ -97,6 +97,7 @@ const SignupGroupForm: React.FC<Props> = ({
   });
   const { deleteSignupGroup, saving: savingSignupGroup } =
     useSignupGroupActions({
+      registration,
       signupGroup,
     });
   const formSavingDisabled = React.useRef(!!readOnly);

--- a/src/domain/signupGroup/signupGroupForm/signups/Signups.tsx
+++ b/src/domain/signupGroup/signupGroupForm/signups/Signups.tsx
@@ -25,11 +25,15 @@ const getSignupPath = (index: number) =>
 
 interface Props {
   formDisabled: boolean;
-  readOnly?: boolean;
+  isEditingMode: boolean;
   registration: Registration;
 }
 
-const Signups: React.FC<Props> = ({ formDisabled, readOnly, registration }) => {
+const Signups: React.FC<Props> = ({
+  formDisabled,
+  isEditingMode,
+  registration,
+}) => {
   const { data: session } = useSession() as { data: ExtendedSession | null };
 
   const indexToRemove = useRef(-1);
@@ -137,9 +141,8 @@ const Signups: React.FC<Props> = ({ formDisabled, readOnly, registration }) => {
                     formDisabled={formDisabled}
                     index={index}
                     onDelete={openModal}
-                    readOnly={readOnly}
                     registration={registration}
-                    showDelete={!readOnly && signups.length > 1}
+                    showDelete={!isEditingMode && signups.length > 1}
                     signup={signup}
                     signupPath={getSignupPath(index)}
                   />

--- a/src/domain/signupGroup/signupGroupForm/signups/signup/Signup.tsx
+++ b/src/domain/signupGroup/signupGroupForm/signups/signup/Signup.tsx
@@ -12,7 +12,7 @@ import FormGroup from '../../../../../common/components/formGroup/FormGroup';
 import useLocale from '../../../../../hooks/useLocale';
 import skipFalsyType from '../../../../../utils/skipFalsyType';
 import { Registration } from '../../../../registration/types';
-import { READ_ONLY_PLACEHOLDER, SIGNUP_FIELDS } from '../../../constants';
+import { SIGNUP_FIELDS } from '../../../constants';
 import InWaitingListInfo from '../../../inWaitingListInfo/InWaitingListInfo';
 import { useSignupGroupFormContext } from '../../../signupGroupFormContext/hooks/useSignupGroupFormContext';
 import { SignupFields } from '../../../types';
@@ -27,7 +27,6 @@ type Props = {
   formDisabled: boolean;
   index: number;
   onDelete: () => void;
-  readOnly?: boolean;
   registration: Registration;
   showDelete: boolean;
   signup: SignupFields;
@@ -41,7 +40,6 @@ const Signup: React.FC<Props> = ({
   formDisabled,
   index,
   onDelete,
-  readOnly,
   registration,
   showDelete,
   signup,
@@ -84,10 +82,7 @@ const Signup: React.FC<Props> = ({
               component={TextInputField}
               disabled={formDisabled}
               label={t(`labelFirstName`)}
-              placeholder={
-                readOnly ? READ_ONLY_PLACEHOLDER : t(`placeholderFirstName`)
-              }
-              readOnly={readOnly}
+              placeholder={t(`placeholderFirstName`)}
               required={isSignupFieldRequired(
                 registration,
                 SIGNUP_FIELDS.FIRST_NAME
@@ -98,10 +93,7 @@ const Signup: React.FC<Props> = ({
               component={TextInputField}
               disabled={formDisabled}
               label={t(`labelLastName`)}
-              placeholder={
-                readOnly ? READ_ONLY_PLACEHOLDER : t(`placeholderLastName`)
-              }
-              readOnly={readOnly}
+              placeholder={t(`placeholderLastName`)}
               required={isSignupFieldRequired(
                 registration,
                 SIGNUP_FIELDS.LAST_NAME
@@ -110,20 +102,13 @@ const Signup: React.FC<Props> = ({
           </div>
         </FormGroup>
         <FormGroup>
-          <div
-            className={classNames(styles.streetAddressRow, {
-              [styles.readOnly]: readOnly,
-            })}
-          >
+          <div className={classNames(styles.streetAddressRow)}>
             <Field
               name={getFieldName(signupPath, SIGNUP_FIELDS.STREET_ADDRESS)}
               component={TextInputField}
               disabled={formDisabled}
               label={t(`labelStreetAddress`)}
-              placeholder={
-                readOnly ? READ_ONLY_PLACEHOLDER : t(`placeholderStreetAddress`)
-              }
-              readOnly={readOnly}
+              placeholder={t(`placeholderStreetAddress`)}
               required={isSignupFieldRequired(
                 registration,
                 SIGNUP_FIELDS.STREET_ADDRESS
@@ -131,41 +116,25 @@ const Signup: React.FC<Props> = ({
             />
             <Field
               name={getFieldName(signupPath, SIGNUP_FIELDS.DATE_OF_BIRTH)}
+              component={DateInputField}
               disabled={formDisabled}
               label={t(`labelDateOfBirth`)}
               language={locale}
-              placeholder={
-                readOnly ? READ_ONLY_PLACEHOLDER : t(`placeholderDateOfBirth`)
-              }
-              readOnly={readOnly}
+              maxDate={new Date()}
+              minDate={new Date(`${new Date().getFullYear() - 100}-01-01`)}
+              placeholder={t(`placeholderDateOfBirth`)}
               required={isDateOfBirthFieldRequired(registration)}
-              {...(readOnly
-                ? { component: TextInputField }
-                : {
-                    component: DateInputField,
-                    maxDate: new Date(),
-                    minDate: new Date(
-                      `${new Date().getFullYear() - 100}-01-01`
-                    ),
-                  })}
             />
           </div>
         </FormGroup>
         <FormGroup>
-          <div
-            className={classNames(styles.zipRow, {
-              [styles.readOnly]: readOnly,
-            })}
-          >
+          <div className={classNames(styles.zipRow)}>
             <Field
               name={getFieldName(signupPath, SIGNUP_FIELDS.ZIPCODE)}
               component={TextInputField}
               disabled={formDisabled}
               label={t(`labelZipcode`)}
-              placeholder={
-                readOnly ? READ_ONLY_PLACEHOLDER : t(`placeholderZipcode`)
-              }
-              readOnly={readOnly}
+              placeholder={t(`placeholderZipcode`)}
               required={isSignupFieldRequired(
                 registration,
                 SIGNUP_FIELDS.ZIPCODE
@@ -176,10 +145,7 @@ const Signup: React.FC<Props> = ({
               component={TextInputField}
               disabled={formDisabled}
               label={t(`labelCity`)}
-              placeholder={
-                readOnly ? READ_ONLY_PLACEHOLDER : t(`placeholderCity`)
-              }
-              readOnly={readOnly}
+              placeholder={t(`placeholderCity`)}
               required={isSignupFieldRequired(registration, SIGNUP_FIELDS.CITY)}
             />
           </div>
@@ -190,10 +156,7 @@ const Signup: React.FC<Props> = ({
           component={TextAreaField}
           disabled={formDisabled}
           label={t(`labelSignupExtraInfo`)}
-          placeholder={
-            readOnly ? READ_ONLY_PLACEHOLDER : t(`placeholderSignupExtraInfo`)
-          }
-          readOnly={readOnly}
+          placeholder={t(`placeholderSignupExtraInfo`)}
           required={isSignupFieldRequired(
             registration,
             SIGNUP_FIELDS.EXTRA_INFO

--- a/src/domain/signupGroup/signupGroupForm/signups/signup/signup.module.scss
+++ b/src/domain/signupGroup/signupGroupForm/signups/signup/signup.module.scss
@@ -46,8 +46,14 @@
 }
 
 .deleteButton {
+  cursor: pointer;
   padding: var(--spacing-s);
   border: none;
+  background-color: var(--color-black-5);
 
   @include focus-outline(-3px);
+
+  &:hover {
+    background-color: var(--color-black-10);
+  }
 }

--- a/src/domain/signupGroup/signupGroupForm/signups/signup/signup.module.scss
+++ b/src/domain/signupGroup/signupGroupForm/signups/signup/signup.module.scss
@@ -28,10 +28,6 @@
 
   @include medium-up {
     grid-template-columns: 4fr 2fr;
-
-    &.readOnly {
-      grid-template-columns: 1fr 1fr;
-    }
   }
 }
 
@@ -42,10 +38,6 @@
 
   @include medium-up {
     grid-template-columns: 2fr 4fr;
-
-    &.readOnly {
-      grid-template-columns: 1fr 1fr;
-    }
   }
 }
 

--- a/src/domain/signupGroup/summaryPage/SummaryPage.tsx
+++ b/src/domain/signupGroup/summaryPage/SummaryPage.tsx
@@ -192,7 +192,7 @@ const SummaryPage: FC<SummaryPageProps> = ({ event, registration }) => {
                       disabled={Boolean(saving)}
                       iconLeft={<IconPen aria-hidden={true} />}
                       isLoading={saving == SIGNUP_GROUP_ACTIONS.CREATE}
-                      loadingText={t('buttonSend') as string}
+                      loadingText={t('buttonSend')}
                       key="save"
                       onClick={handleSubmit}
                     >

--- a/src/domain/signupGroup/summaryPage/SummaryPage.tsx
+++ b/src/domain/signupGroup/summaryPage/SummaryPage.tsx
@@ -21,10 +21,7 @@ import { Event } from '../../event/types';
 import NotFound from '../../notFound/NotFound';
 import useEventAndRegistrationData from '../../registration/hooks/useEventAndRegistrationData';
 import { Registration } from '../../registration/types';
-import {
-  clearSeatsReservationData,
-  getSeatsReservationData,
-} from '../../reserveSeats/utils';
+import { clearSeatsReservationData } from '../../reserveSeats/utils';
 import { SIGNUP_QUERY_PARAMS } from '../../signup/constants';
 import { useSignupServerErrorsContext } from '../../signup/signupServerErrorsContext/hooks/useSignupServerErrorsContext';
 import { SignupServerErrorsProvider } from '../../signup/signupServerErrorsContext/SignupServerErrorsContext';
@@ -39,7 +36,6 @@ import { SignupGroupFormProvider } from '../signupGroupFormContext/SignupGroupFo
 import {
   clearCreateSignupGroupFormData,
   getSignupGroupDefaultInitialValues,
-  getSignupGroupPayload,
 } from '../utils';
 import { getSignupGroupSchema } from '../validation';
 
@@ -59,7 +55,7 @@ const SummaryPage: FC<SummaryPageProps> = ({ event, registration }) => {
     data: ExtendedSession | null;
   };
 
-  const { createSignupGroup, saving } = useSignupGroupActions();
+  const { createSignupGroup, saving } = useSignupGroupActions({ registration });
 
   const reservationTimerCallbacksDisabled = useRef(false);
   const disableReservationTimerCallbacks = useCallback(() => {
@@ -137,16 +133,7 @@ const SummaryPage: FC<SummaryPageProps> = ({ event, registration }) => {
                   abortEarly: true,
                 });
 
-                const reservationData = getSeatsReservationData(
-                  registration.id
-                );
-                const payload = getSignupGroupPayload({
-                  formValues: values,
-                  registration,
-                  reservationCode: reservationData?.code as string,
-                });
-
-                createSignupGroup(payload, {
+                createSignupGroup(values, {
                   onError: (error) =>
                     showServerErrors(
                       { error: JSON.parse(error.message) },

--- a/src/domain/signupGroup/testUtils.ts
+++ b/src/domain/signupGroup/testUtils.ts
@@ -21,6 +21,7 @@ export const getSignupFormElement = (
     | 'serviceLanguageButton'
     | 'streetAddressInput'
     | 'submitButton'
+    | 'updateButton'
     | 'updateParticipantAmountButton'
     | 'zipInput'
 ) => {
@@ -59,6 +60,8 @@ export const getSignupFormElement = (
       return screen.getByLabelText(/katuosoite/i);
     case 'submitButton':
       return screen.getByRole('button', { name: /jatka ilmoittautumiseen/i });
+    case 'updateButton':
+      return screen.getByRole('button', { name: /tallenna/i });
     case 'updateParticipantAmountButton':
       return screen.getByRole('button', { name: /päivitä/i });
     case 'zipInput':
@@ -67,32 +70,20 @@ export const getSignupFormElement = (
 };
 
 export const shouldRenderSignupFormFields = async () => {
-  const firstNameInput = await findFirstNameInput();
-  const lastNameInput = getSignupFormElement('lastNameInput');
-  const streetAddressInput = getSignupFormElement('streetAddressInput');
-  const dateOfBirthInput = getSignupFormElement('dateOfBirthInput');
-  const zipInput = getSignupFormElement('zipInput');
-  const cityInput = getSignupFormElement('cityInput');
-  const emailInput = getSignupFormElement('emailInput');
-  const phoneInput = getSignupFormElement('phoneInput');
-  const emailCheckbox = getSignupFormElement('emailCheckbox');
-  const phoneCheckbox = getSignupFormElement('phoneCheckbox');
-  const nativeLanguageButton = getSignupFormElement('nativeLanguageButton');
-  const serviceLanguageButton = getSignupFormElement('serviceLanguageButton');
+  await findFirstNameInput();
+  getSignupFormElement('lastNameInput');
+  getSignupFormElement('streetAddressInput');
+  getSignupFormElement('dateOfBirthInput');
+  getSignupFormElement('zipInput');
+  getSignupFormElement('cityInput');
+  getSignupFormElement('emailInput');
+  getSignupFormElement('phoneInput');
+  getSignupFormElement('emailCheckbox');
+  getSignupFormElement('phoneCheckbox');
+  getSignupFormElement('nativeLanguageButton');
+  getSignupFormElement('serviceLanguageButton');
   getSignupFormElement('cancelButton');
-
-  expect(firstNameInput.hasAttribute('readonly')).toBeTruthy();
-  expect(lastNameInput.hasAttribute('readonly')).toBeTruthy();
-  expect(streetAddressInput.hasAttribute('readonly')).toBeTruthy();
-  expect(dateOfBirthInput.hasAttribute('readonly')).toBeTruthy();
-  expect(zipInput.hasAttribute('readonly')).toBeTruthy();
-  expect(cityInput.hasAttribute('readonly')).toBeTruthy();
-  expect(emailInput.hasAttribute('readonly')).toBeTruthy();
-  expect(phoneInput.hasAttribute('readonly')).toBeTruthy();
-  expect(emailCheckbox).toBeDisabled();
-  expect(phoneCheckbox).toBeDisabled();
-  expect(nativeLanguageButton).toBeDisabled();
-  expect(serviceLanguageButton).toBeDisabled();
+  getSignupFormElement('updateButton');
 };
 
 export const tryToCancel = async () => {
@@ -108,4 +99,10 @@ export const tryToCancel = async () => {
     name: 'Peruuta ilmoittautuminen',
   });
   await user.click(cancelSignupButton);
+};
+
+export const tryToUpdate = async () => {
+  const user = userEvent.setup();
+  const updateButton = getSignupFormElement('updateButton');
+  await user.click(updateButton);
 };

--- a/src/domain/signupGroup/types.ts
+++ b/src/domain/signupGroup/types.ts
@@ -10,12 +10,19 @@ export type CreateSignupGroupMutationInput = {
   signups: SignupInput[];
 };
 
+export type UpdateSignupGroupMutationInput = { id: string } & Omit<
+  CreateSignupGroupMutationInput,
+  'reservation_code'
+>;
+
 export type CreateSignupGroupResponse = {
   extra_info: string;
   id: string;
   registration: string;
   signups: Signup[];
 };
+
+export type UpdateSignupGroupResponse = CreateSignupGroupResponse;
 
 export type SignupGroup = {
   created_at: stringOrNull;

--- a/src/domain/signupGroup/types.ts
+++ b/src/domain/signupGroup/types.ts
@@ -15,14 +15,12 @@ export type UpdateSignupGroupMutationInput = { id: string } & Omit<
   'reservation_code'
 >;
 
-export type CreateSignupGroupResponse = {
+export type CreateOrUpdateSignupGroupResponse = {
   extra_info: string;
   id: string;
   registration: string;
   signups: Signup[];
 };
-
-export type UpdateSignupGroupResponse = CreateSignupGroupResponse;
 
 export type SignupGroup = {
   created_at: stringOrNull;

--- a/src/domain/signupGroup/utils.ts
+++ b/src/domain/signupGroup/utils.ts
@@ -4,15 +4,18 @@ import snakeCase from 'lodash/snakeCase';
 
 import { FORM_NAMES } from '../../constants';
 import { ExtendedSession } from '../../types';
-import formatDate from '../../utils/formatDate';
 import skipFalsyType from '../../utils/skipFalsyType';
-import stringToDate from '../../utils/stringToDate';
-import { callDelete, callGet, callPost } from '../app/axios/axiosClient';
+import {
+  callDelete,
+  callGet,
+  callPost,
+  callPut,
+} from '../app/axios/axiosClient';
 import { Registration } from '../registration/types';
 import { SeatsReservation } from '../reserveSeats/types';
 import { NOTIFICATION_TYPE } from '../signup/constants';
 import { Signup, SignupInput } from '../signup/types';
-import { getSignupInitialValues } from '../signup/utils';
+import { getSignupInitialValues, getSignupPayload } from '../signup/utils';
 
 import {
   NOTIFICATIONS,
@@ -28,6 +31,8 @@ import {
   SignupGroup,
   SignupGroupFormFields,
   SignupGroupQueryVariables,
+  UpdateSignupGroupMutationInput,
+  UpdateSignupGroupResponse,
 } from './types';
 
 export const getSignupNotificationsCode = (
@@ -62,25 +67,6 @@ export const getSignupNotificationTypes = (
   }
 };
 
-export const createSignupGroup = async ({
-  input,
-  session,
-}: {
-  input: CreateSignupGroupMutationInput;
-  session: ExtendedSession | null;
-}): Promise<CreateSignupGroupResponse> => {
-  try {
-    const { data } = await callPost({
-      data: JSON.stringify(input),
-      session,
-      url: `/signup_group/`,
-    });
-    return data;
-  } catch (error) {
-    throw Error(JSON.stringify((error as AxiosError).response?.data));
-  }
-};
-
 export const getSignupGroupPayload = ({
   formValues,
   registration,
@@ -90,52 +76,47 @@ export const getSignupGroupPayload = ({
   registration: Registration;
   reservationCode: string;
 }): CreateSignupGroupMutationInput => {
-  const {
-    email,
-    extraInfo: groupExtraInfo,
-    membershipNumber,
-    nativeLanguage,
-    phoneNumber,
-    serviceLanguage,
-    signups: signupsValues,
-  } = formValues;
+  const { extraInfo: groupExtraInfo, signups: signupsValues } = formValues;
 
-  const signups: SignupInput[] = signupsValues.map((signup, index) => {
-    const {
-      city,
-      dateOfBirth,
-      extraInfo,
-      firstName,
-      lastName,
-      streetAddress,
-      zipcode,
-    } = signup;
-    return {
-      city: city || '',
-      date_of_birth: dateOfBirth
-        ? formatDate(stringToDate(dateOfBirth), 'yyyy-MM-dd')
-        : null,
-      email: email || null,
-      extra_info: extraInfo,
-      first_name: firstName || '',
-      last_name: lastName || '',
-      membership_number: membershipNumber,
-      native_language: nativeLanguage || null,
-      // TODO: At the moment only email notifications are supported
-      notifications: NOTIFICATION_TYPE.EMAIL,
-      // notifications: getSignupNotificationsCode(notifications),
-      phone_number: phoneNumber || null,
-      responsible_for_group: index == 0,
-      service_language: serviceLanguage || null,
-      street_address: streetAddress || null,
-      zipcode: zipcode || null,
-    };
-  });
+  const signups: SignupInput[] = signupsValues.map((signupData, index) =>
+    getSignupPayload({
+      formValues,
+      responsibleForGroup: index === 0,
+      signupData,
+    })
+  );
 
   return {
     extra_info: groupExtraInfo,
     registration: registration.id,
     reservation_code: reservationCode,
+    signups,
+  };
+};
+
+export const getUpdateSignupGroupPayload = ({
+  formValues,
+  id,
+  registration,
+}: {
+  formValues: SignupGroupFormFields;
+  id: string;
+  registration: Registration;
+}): UpdateSignupGroupMutationInput => {
+  const { extraInfo: groupExtraInfo, signups: signupsValues } = formValues;
+
+  const signups: SignupInput[] = signupsValues.map((signupData) =>
+    getSignupPayload({
+      formValues,
+      responsibleForGroup: signupData.responsibleForGroup,
+      signupData,
+    })
+  );
+
+  return {
+    extra_info: groupExtraInfo,
+    id,
+    registration: registration.id,
     signups,
   };
 };
@@ -223,6 +204,25 @@ export const signupGroupPathBuilder = (
   return `/signup_group/${args.id}/`;
 };
 
+export const createSignupGroup = async ({
+  input,
+  session,
+}: {
+  input: CreateSignupGroupMutationInput;
+  session: ExtendedSession | null;
+}): Promise<CreateSignupGroupResponse> => {
+  try {
+    const { data } = await callPost({
+      data: JSON.stringify(input),
+      session,
+      url: `/signup_group/`,
+    });
+    return data;
+  } catch (error) {
+    throw Error(JSON.stringify((error as AxiosError).response?.data));
+  }
+};
+
 export const fetchSignupGroup = async (
   args: SignupGroupQueryVariables,
   session: ExtendedSession | null
@@ -250,6 +250,25 @@ export const deleteSignupGroup = async ({
     const { data } = await callDelete({
       session,
       url: signupGroupPathBuilder({ id }),
+    });
+    return data;
+  } catch (error) {
+    throw Error(JSON.stringify((error as AxiosError).response?.data));
+  }
+};
+
+export const updateSignupGroup = async ({
+  input: { id, ...input },
+  session,
+}: {
+  input: UpdateSignupGroupMutationInput;
+  session: ExtendedSession | null;
+}): Promise<UpdateSignupGroupResponse> => {
+  try {
+    const { data } = await callPut({
+      data: JSON.stringify(input),
+      session,
+      url: signupGroupPathBuilder({ id: id as string }),
     });
     return data;
   } catch (error) {

--- a/src/domain/signupGroup/utils.ts
+++ b/src/domain/signupGroup/utils.ts
@@ -26,13 +26,12 @@ import {
 } from './constants';
 import {
   CreateSignupGroupMutationInput,
-  CreateSignupGroupResponse,
+  CreateOrUpdateSignupGroupResponse,
   SignupFields,
   SignupGroup,
   SignupGroupFormFields,
   SignupGroupQueryVariables,
   UpdateSignupGroupMutationInput,
-  UpdateSignupGroupResponse,
 } from './types';
 
 export const getSignupNotificationsCode = (
@@ -210,7 +209,7 @@ export const createSignupGroup = async ({
 }: {
   input: CreateSignupGroupMutationInput;
   session: ExtendedSession | null;
-}): Promise<CreateSignupGroupResponse> => {
+}): Promise<CreateOrUpdateSignupGroupResponse> => {
   try {
     const { data } = await callPost({
       data: JSON.stringify(input),
@@ -263,12 +262,12 @@ export const updateSignupGroup = async ({
 }: {
   input: UpdateSignupGroupMutationInput;
   session: ExtendedSession | null;
-}): Promise<UpdateSignupGroupResponse> => {
+}): Promise<CreateOrUpdateSignupGroupResponse> => {
   try {
     const { data } = await callPut({
       data: JSON.stringify(input),
       session,
-      url: signupGroupPathBuilder({ id: id as string }),
+      url: signupGroupPathBuilder({ id }),
     });
     return data;
   } catch (error) {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -5,6 +5,7 @@ body {
   --label-height: 1.75rem;
   --focus-outline-width: 3px;
   --focus-outline-color: var(--color-coat-of-arms);
+  --toastify-color-success: var(--color-success);
 
   padding: 0;
   margin: 0;

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -1,11 +1,7 @@
 @mixin focus-outline($offset: 0px, $color: var(--focus-outline-color)) {
   &:focus {
-    outline: var(--focus-outline-width) solid $color;
+    outline: var(--focus-outline-width) solid $color !important;
     outline-offset: $offset;
-
-    // &:not(:global(.focus-visible)) {
-    //   outline: none;
-    // }
   }
 }
 

--- a/src/utils/testUtils.tsx
+++ b/src/utils/testUtils.tsx
@@ -20,6 +20,7 @@ import React, { useMemo } from 'react';
 import wait from 'waait';
 
 import { testId } from '../common/components/loadingSpinner/LoadingSpinner';
+import { SignupGroupFormProvider } from '../domain/signupGroup/signupGroupFormContext/SignupGroupFormContext';
 import { server } from '../tests/msw/server';
 import { ExtendedSession } from '../types';
 
@@ -122,7 +123,11 @@ export const getQueryWrapper = (session: ExtendedSession | null = null) => {
 
   const wrapper = ({ children }: { children: React.ReactNode }) => (
     <SessionProvider session={session}>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      <SignupGroupFormProvider>
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      </SignupGroupFormProvider>
     </SessionProvider>
   );
 


### PR DESCRIPTION
## Description :sparkles:
Replace LoadingButton component with HDS Button

This is one of the 5 PRs that replaced https://github.com/City-of-Helsinki/linkedregistrations-ui/pull/74. The purpose of these PRs is to implement pages to update signups and signup groups

PR Parts:
- Replace LoadingButton component with HDS Button (https://github.com/City-of-Helsinki/linkedregistrations-ui/pull/81)
- Move signup form test util functions to separate file (https://github.com/City-of-Helsinki/linkedregistrations-ui/pull/82)
- **Move delete signup button to the page bottom**
- Util functions and queries to update signups and signups groups (https://github.com/City-of-Helsinki/linkedregistrations-ui/pull/84)
- Changes in UI components to support updating signup or signup group (https://github.com/City-of-Helsinki/linkedregistrations-ui/pull/85)

## Partially closes
[LINK-1484](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1484)


[LINK-1484]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ