### PR TITLE
LINK-1484 |  5/5 Changes in UI components to support updating signup or signup group

### DIFF
--- a/public/locales/en/signup.json
+++ b/public/locales/en/signup.json
@@ -2,6 +2,7 @@
   "buttonCancel": "Cancel registration",
   "buttonDeleteSignup": "Delete participant",
   "buttonGoToSummary": "Continue to registration",
+  "buttonUpdate": "Save",
   "buttonUpdateParticipantAmount": "Update",
   "cancelledPage": {
     "text": "You have canceled your registration for our event {{name}}.",
@@ -64,6 +65,8 @@
     "email": "By email",
     "sms": "By text message"
   },
+  "notificationSignupUpdated": "The signup has been saved",
+  "notificationSignupGroupUpdated": "The signup group has been saved",
   "personsAddedToWaitingListModal": {
     "buttonClose": "Close",
     "text": "Please note that not all registrants' places are guaranteed. Entrants in the reserve position will only be confirmed if more places become available in the queue. You will receive a separate email from confirmed registration.",

--- a/public/locales/fi/signup.json
+++ b/public/locales/fi/signup.json
@@ -2,6 +2,7 @@
   "buttonCancel": "Peruuta ilmoittautuminen",
   "buttonDeleteSignup": "Poista osallistuja",
   "buttonGoToSummary": "Jatka ilmoittautumiseen",
+  "buttonUpdate": "Tallenna",
   "buttonUpdateParticipantAmount": "Päivitä",
   "cancelledPage": {
     "text": "Olet perunut ilmoittautumisesi tapahtumaamme {{name}}.",
@@ -64,6 +65,8 @@
     "email": "Sähköpostilla",
     "sms": "Tekstiviestillä"
   },
+  "notificationSignupUpdated": "Osallistujan tiedot on tallennettu",
+  "notificationSignupGroupUpdated": "Osallistujien tiedot on tallennettu",
   "personsAddedToWaitingListModal": {
     "buttonClose": "Sulje",
     "text": "Huomioi, että kaikki ilmoittautujien paikat eivät ole varmistettuja. Varasijalla olevat ilmoittautujat varmistuvat vain, jos jonosta vapautuu lisää paikkoja. Varmistuneesta ilmoittautumisesta saat erillisen sähköpostin.",

--- a/public/locales/sv/signup.json
+++ b/public/locales/sv/signup.json
@@ -2,6 +2,7 @@
   "buttonCancel": "Avbryt registreringen",
   "buttonDeleteSignup": "Ta bort deltagare",
   "buttonGoToSummary": "Fortsätt till registreringen",
+  "buttonUpdate": "Spara",
   "buttonUpdateParticipantAmount": "Uppdatera",
   "cancelledPage": {
     "text": "Du har avbokat din anmälan till vårt evenemang {{name}}.",
@@ -64,6 +65,8 @@
     "email": "Via e-post",
     "sms": "Med sms"
   },
+  "notificationSignupUpdated": "Deltagarinformation har sparad",
+  "notificationSignupGroupUpdated": "Deltagarinformation har sparad",
   "personsAddedToWaitingListModal": {
     "buttonClose": "Stänga",
     "text": "Observera att inte alla anmäldas platser är garanterade. Deltagare på reservplatsen bekräftas endast om fler platser blir lediga i kön. Du kommer att få ett separat e-postmeddelande från bekräftad registrering.",

--- a/src/domain/signup/EditSignupPage.tsx
+++ b/src/domain/signup/EditSignupPage.tsx
@@ -33,7 +33,7 @@ const EditSignupPage: React.FC<Props> = ({ event, registration, signup }) => {
       <SignupGroupForm
         event={event}
         initialValues={initialValues}
-        readOnly={true}
+        mode="update-signup"
         registration={registration}
         signup={signup}
       />

--- a/src/domain/signup/__mocks__/signup.ts
+++ b/src/domain/signup/__mocks__/signup.ts
@@ -1,8 +1,13 @@
+import subYears from 'date-fns/subYears';
+
+import formatDate from '../../../utils/formatDate';
 import { fakeSignup } from '../../../utils/mockDataUtils';
 import { TEST_SIGNUP_ID } from '../constants';
 
 const signup = fakeSignup({
   id: TEST_SIGNUP_ID,
+  date_of_birth: formatDate(subYears(new Date(), 15), 'yyyy-MM-dd'),
+  phone_number: '0441234567',
 });
 
 export { signup };

--- a/src/domain/signup/__tests__/EditSignupPage.test.tsx
+++ b/src/domain/signup/__tests__/EditSignupPage.test.tsx
@@ -6,6 +6,7 @@ import singletonRouter from 'next/router';
 import * as nextAuth from 'next-auth/react';
 import mockRouter from 'next-router-mock';
 import React from 'react';
+import { toast } from 'react-toastify';
 
 import { ExtendedSession } from '../../../types';
 import { fakeAuthenticatedSession } from '../../../utils/mockSession';
@@ -26,6 +27,7 @@ import {
   findFirstNameInput,
   shouldRenderSignupFormFields,
   tryToCancel,
+  tryToUpdate,
 } from '../../signupGroup/testUtils';
 import { signup } from '../__mocks__/signup';
 import { TEST_SIGNUP_ID } from '../constants';
@@ -110,6 +112,45 @@ test('should show error message when cancelling signup fails', async () => {
 
   await findFirstNameInput();
   await tryToCancel();
+
+  await screen.findByRole(
+    'heading',
+    { name: /lomakkeella on seuraavat virheet/i },
+    { timeout: 10000 }
+  );
+});
+
+test('should update signup', async () => {
+  toast.success = jest.fn();
+  setQueryMocks(
+    ...defaultMocks,
+    rest.put(`*/signup/${TEST_SIGNUP_ID}`, (req, res, ctx) =>
+      res(ctx.status(201), ctx.json(signup))
+    )
+  );
+  pushEditSignupRoute(TEST_REGISTRATION_ID);
+  renderComponent();
+
+  await findFirstNameInput();
+  await tryToUpdate();
+
+  await waitFor(() =>
+    expect(toast.success).toBeCalledWith('Osallistujan tiedot on tallennettu')
+  );
+});
+
+test('should show error message when updating signup fails', async () => {
+  setQueryMocks(
+    ...defaultMocks,
+    rest.put(`*/signup/${TEST_SIGNUP_ID}`, (req, res, ctx) =>
+      res(ctx.status(403), ctx.json({ name: 'Name is required.' }))
+    )
+  );
+  pushEditSignupRoute(TEST_REGISTRATION_ID);
+  renderComponent();
+
+  await findFirstNameInput();
+  await tryToUpdate();
 
   await screen.findByRole(
     'heading',

--- a/src/domain/signup/utils.ts
+++ b/src/domain/signup/utils.ts
@@ -65,7 +65,7 @@ export const updateSignup = async ({
     const { data } = await callPut({
       data: JSON.stringify(input),
       session,
-      url: signupPathBuilder({ id: id as string }),
+      url: signupPathBuilder({ id }),
     });
     return data;
   } catch (error) {

--- a/src/domain/signupGroup/CreateSignupGroupPage.tsx
+++ b/src/domain/signupGroup/CreateSignupGroupPage.tsx
@@ -48,6 +48,7 @@ const CreateSignupGroupPage: React.FC<Props> = ({ event, registration }) => {
         <SignupGroupForm
           event={event}
           initialValues={initialValues}
+          mode="create-signup-group"
           registration={registration}
         />
       )}

--- a/src/domain/signupGroup/EditSignupGroupPage.tsx
+++ b/src/domain/signupGroup/EditSignupGroupPage.tsx
@@ -37,7 +37,7 @@ const EditSignupGroupPage: React.FC<Props> = ({
       <SignupGroupForm
         event={event}
         initialValues={initialValues}
-        readOnly={true}
+        mode="update-signup-group"
         registration={registration}
         signupGroup={signupGroup}
       />

--- a/src/domain/signupGroup/__mocks__/signupGroup.ts
+++ b/src/domain/signupGroup/__mocks__/signupGroup.ts
@@ -1,10 +1,11 @@
-import { fakeSignup, fakeSignupGroup } from '../../../utils/mockDataUtils';
-import { TEST_SIGNUP_ID } from '../../signup/constants';
+import { fakeSignupGroup } from '../../../utils/mockDataUtils';
+import { signup } from '../../signup/__mocks__/signup';
 import { TEST_SIGNUP_GROUP_ID } from '../constants';
 
 const signupGroup = fakeSignupGroup({
   id: TEST_SIGNUP_GROUP_ID,
-  signups: [fakeSignup({ id: TEST_SIGNUP_ID })],
+
+  signups: [signup],
 });
 
 export { signupGroup };

--- a/src/domain/signupGroup/constants.ts
+++ b/src/domain/signupGroup/constants.ts
@@ -66,6 +66,4 @@ export enum SIGNUP_GROUP_ACTIONS {
   UPDATE = 'update',
 }
 
-export const READ_ONLY_PLACEHOLDER = '-';
-
 export const TEST_SIGNUP_GROUP_ID = 'signupGroup:1';

--- a/src/domain/signupGroup/editButtonPanel/EditButtonPanel.tsx
+++ b/src/domain/signupGroup/editButtonPanel/EditButtonPanel.tsx
@@ -1,16 +1,24 @@
-import { Button, IconCross } from 'hds-react';
+import { Button, IconCross, IconPen } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 
 import ButtonPanel from '../../../common/components/buttonPanel/ButtonPanel';
+import { SIGNUP_ACTIONS } from '../../signup/constants';
+import { SIGNUP_GROUP_ACTIONS } from '../constants';
 
 type EditButtonPanelProps = {
   disabled: boolean;
-  onDelete: () => void;
+  onCancel: () => void;
+  onUpdate: () => void;
+  savingSignup: SIGNUP_ACTIONS | null;
+  savingSignupGroup: SIGNUP_GROUP_ACTIONS | null;
 };
 
 const EditButtonPanel: React.FC<EditButtonPanelProps> = ({
   disabled,
-  onDelete,
+  onCancel,
+  onUpdate,
+  savingSignup,
+  savingSignupGroup,
 }) => {
   const { t } = useTranslation('signup');
   return (
@@ -18,12 +26,30 @@ const EditButtonPanel: React.FC<EditButtonPanelProps> = ({
       submitButtons={[
         <Button
           key="cancel"
-          disabled={disabled}
           iconLeft={<IconCross aria-hidden={true} />}
-          onClick={onDelete}
+          onClick={onCancel}
           variant="danger"
         >
           {t('buttonCancel')}
+        </Button>,
+
+        <Button
+          key="update"
+          disabled={Boolean(
+            disabled ||
+              savingSignup === SIGNUP_ACTIONS.UPDATE ||
+              savingSignupGroup === SIGNUP_GROUP_ACTIONS.UPDATE
+          )}
+          iconLeft={<IconPen aria-hidden={true} />}
+          isLoading={
+            savingSignup === SIGNUP_ACTIONS.UPDATE ||
+            savingSignupGroup === SIGNUP_GROUP_ACTIONS.UPDATE
+          }
+          loadingText={t('buttonUpdate') as string}
+          onClick={onUpdate}
+          variant="primary"
+        >
+          {t('buttonUpdate')}
         </Button>,
       ]}
     ></ButtonPanel>

--- a/src/domain/signupGroup/mutation.ts
+++ b/src/domain/signupGroup/mutation.ts
@@ -8,10 +8,9 @@ import { ExtendedSession } from '../../types';
 
 import {
   CreateSignupGroupMutationInput,
-  CreateSignupGroupResponse,
+  CreateOrUpdateSignupGroupResponse,
   DeleteSignupGroupMutationInput,
   UpdateSignupGroupMutationInput,
-  UpdateSignupGroupResponse,
 } from './types';
 import {
   createSignupGroup,
@@ -24,13 +23,13 @@ export const useCreateSignupGroupMutation = ({
   session,
 }: {
   options?: UseMutationOptions<
-    CreateSignupGroupResponse,
+    CreateOrUpdateSignupGroupResponse,
     Error,
     CreateSignupGroupMutationInput
   >;
   session: ExtendedSession | null;
 }): UseMutationResult<
-  CreateSignupGroupResponse,
+  CreateOrUpdateSignupGroupResponse,
   Error,
   CreateSignupGroupMutationInput
 > => {
@@ -59,13 +58,13 @@ export const useUpdateSignupGroupMutation = ({
   session,
 }: {
   options?: UseMutationOptions<
-    UpdateSignupGroupResponse,
+    CreateOrUpdateSignupGroupResponse,
     Error,
     UpdateSignupGroupMutationInput
   >;
   session: ExtendedSession | null;
 }): UseMutationResult<
-  UpdateSignupGroupResponse,
+  CreateOrUpdateSignupGroupResponse,
   Error,
   UpdateSignupGroupMutationInput
 > => {

--- a/src/domain/signupGroup/signupGroupForm/signups/Signups.tsx
+++ b/src/domain/signupGroup/signupGroupForm/signups/Signups.tsx
@@ -25,11 +25,15 @@ const getSignupPath = (index: number) =>
 
 interface Props {
   formDisabled: boolean;
-  readOnly?: boolean;
+  isEditingMode: boolean;
   registration: Registration;
 }
 
-const Signups: React.FC<Props> = ({ formDisabled, readOnly, registration }) => {
+const Signups: React.FC<Props> = ({
+  formDisabled,
+  isEditingMode,
+  registration,
+}) => {
   const { data: session } = useSession() as { data: ExtendedSession | null };
 
   const indexToRemove = useRef(-1);
@@ -137,9 +141,8 @@ const Signups: React.FC<Props> = ({ formDisabled, readOnly, registration }) => {
                     formDisabled={formDisabled}
                     index={index}
                     onDelete={openModal}
-                    readOnly={readOnly}
                     registration={registration}
-                    showDelete={!readOnly && signups.length > 1}
+                    showDelete={!isEditingMode && signups.length > 1}
                     signup={signup}
                     signupPath={getSignupPath(index)}
                   />

--- a/src/domain/signupGroup/signupGroupForm/signups/signup/Signup.tsx
+++ b/src/domain/signupGroup/signupGroupForm/signups/signup/Signup.tsx
@@ -12,7 +12,7 @@ import FormGroup from '../../../../../common/components/formGroup/FormGroup';
 import useLocale from '../../../../../hooks/useLocale';
 import skipFalsyType from '../../../../../utils/skipFalsyType';
 import { Registration } from '../../../../registration/types';
-import { READ_ONLY_PLACEHOLDER, SIGNUP_FIELDS } from '../../../constants';
+import { SIGNUP_FIELDS } from '../../../constants';
 import InWaitingListInfo from '../../../inWaitingListInfo/InWaitingListInfo';
 import { useSignupGroupFormContext } from '../../../signupGroupFormContext/hooks/useSignupGroupFormContext';
 import { SignupFields } from '../../../types';
@@ -27,7 +27,6 @@ type Props = {
   formDisabled: boolean;
   index: number;
   onDelete: () => void;
-  readOnly?: boolean;
   registration: Registration;
   showDelete: boolean;
   signup: SignupFields;
@@ -41,7 +40,6 @@ const Signup: React.FC<Props> = ({
   formDisabled,
   index,
   onDelete,
-  readOnly,
   registration,
   showDelete,
   signup,
@@ -84,10 +82,7 @@ const Signup: React.FC<Props> = ({
               component={TextInputField}
               disabled={formDisabled}
               label={t(`labelFirstName`)}
-              placeholder={
-                readOnly ? READ_ONLY_PLACEHOLDER : t(`placeholderFirstName`)
-              }
-              readOnly={readOnly}
+              placeholder={t(`placeholderFirstName`)}
               required={isSignupFieldRequired(
                 registration,
                 SIGNUP_FIELDS.FIRST_NAME
@@ -98,10 +93,7 @@ const Signup: React.FC<Props> = ({
               component={TextInputField}
               disabled={formDisabled}
               label={t(`labelLastName`)}
-              placeholder={
-                readOnly ? READ_ONLY_PLACEHOLDER : t(`placeholderLastName`)
-              }
-              readOnly={readOnly}
+              placeholder={t(`placeholderLastName`)}
               required={isSignupFieldRequired(
                 registration,
                 SIGNUP_FIELDS.LAST_NAME
@@ -110,20 +102,13 @@ const Signup: React.FC<Props> = ({
           </div>
         </FormGroup>
         <FormGroup>
-          <div
-            className={classNames(styles.streetAddressRow, {
-              [styles.readOnly]: readOnly,
-            })}
-          >
+          <div className={classNames(styles.streetAddressRow)}>
             <Field
               name={getFieldName(signupPath, SIGNUP_FIELDS.STREET_ADDRESS)}
               component={TextInputField}
               disabled={formDisabled}
               label={t(`labelStreetAddress`)}
-              placeholder={
-                readOnly ? READ_ONLY_PLACEHOLDER : t(`placeholderStreetAddress`)
-              }
-              readOnly={readOnly}
+              placeholder={t(`placeholderStreetAddress`)}
               required={isSignupFieldRequired(
                 registration,
                 SIGNUP_FIELDS.STREET_ADDRESS
@@ -131,41 +116,25 @@ const Signup: React.FC<Props> = ({
             />
             <Field
               name={getFieldName(signupPath, SIGNUP_FIELDS.DATE_OF_BIRTH)}
+              component={DateInputField}
               disabled={formDisabled}
               label={t(`labelDateOfBirth`)}
               language={locale}
-              placeholder={
-                readOnly ? READ_ONLY_PLACEHOLDER : t(`placeholderDateOfBirth`)
-              }
-              readOnly={readOnly}
+              maxDate={new Date()}
+              minDate={new Date(`${new Date().getFullYear() - 100}-01-01`)}
+              placeholder={t(`placeholderDateOfBirth`)}
               required={isDateOfBirthFieldRequired(registration)}
-              {...(readOnly
-                ? { component: TextInputField }
-                : {
-                    component: DateInputField,
-                    maxDate: new Date(),
-                    minDate: new Date(
-                      `${new Date().getFullYear() - 100}-01-01`
-                    ),
-                  })}
             />
           </div>
         </FormGroup>
         <FormGroup>
-          <div
-            className={classNames(styles.zipRow, {
-              [styles.readOnly]: readOnly,
-            })}
-          >
+          <div className={classNames(styles.zipRow)}>
             <Field
               name={getFieldName(signupPath, SIGNUP_FIELDS.ZIPCODE)}
               component={TextInputField}
               disabled={formDisabled}
               label={t(`labelZipcode`)}
-              placeholder={
-                readOnly ? READ_ONLY_PLACEHOLDER : t(`placeholderZipcode`)
-              }
-              readOnly={readOnly}
+              placeholder={t(`placeholderZipcode`)}
               required={isSignupFieldRequired(
                 registration,
                 SIGNUP_FIELDS.ZIPCODE
@@ -176,10 +145,7 @@ const Signup: React.FC<Props> = ({
               component={TextInputField}
               disabled={formDisabled}
               label={t(`labelCity`)}
-              placeholder={
-                readOnly ? READ_ONLY_PLACEHOLDER : t(`placeholderCity`)
-              }
-              readOnly={readOnly}
+              placeholder={t(`placeholderCity`)}
               required={isSignupFieldRequired(registration, SIGNUP_FIELDS.CITY)}
             />
           </div>
@@ -190,10 +156,7 @@ const Signup: React.FC<Props> = ({
           component={TextAreaField}
           disabled={formDisabled}
           label={t(`labelSignupExtraInfo`)}
-          placeholder={
-            readOnly ? READ_ONLY_PLACEHOLDER : t(`placeholderSignupExtraInfo`)
-          }
-          readOnly={readOnly}
+          placeholder={t(`placeholderSignupExtraInfo`)}
           required={isSignupFieldRequired(
             registration,
             SIGNUP_FIELDS.EXTRA_INFO

--- a/src/domain/signupGroup/signupGroupForm/signups/signup/signup.module.scss
+++ b/src/domain/signupGroup/signupGroupForm/signups/signup/signup.module.scss
@@ -46,8 +46,14 @@
 }
 
 .deleteButton {
+  cursor: pointer;
   padding: var(--spacing-s);
   border: none;
+  background-color: var(--color-black-5);
 
   @include focus-outline(-3px);
+
+  &:hover {
+    background-color: var(--color-black-10);
+  }
 }

--- a/src/domain/signupGroup/signupGroupForm/signups/signup/signup.module.scss
+++ b/src/domain/signupGroup/signupGroupForm/signups/signup/signup.module.scss
@@ -28,10 +28,6 @@
 
   @include medium-up {
     grid-template-columns: 4fr 2fr;
-
-    &.readOnly {
-      grid-template-columns: 1fr 1fr;
-    }
   }
 }
 
@@ -42,10 +38,6 @@
 
   @include medium-up {
     grid-template-columns: 2fr 4fr;
-
-    &.readOnly {
-      grid-template-columns: 1fr 1fr;
-    }
   }
 }
 

--- a/src/domain/signupGroup/summaryPage/SummaryPage.tsx
+++ b/src/domain/signupGroup/summaryPage/SummaryPage.tsx
@@ -192,7 +192,7 @@ const SummaryPage: FC<SummaryPageProps> = ({ event, registration }) => {
                       disabled={Boolean(saving)}
                       iconLeft={<IconPen aria-hidden={true} />}
                       isLoading={saving == SIGNUP_GROUP_ACTIONS.CREATE}
-                      loadingText={t('buttonSend') as string}
+                      loadingText={t('buttonSend')}
                       key="save"
                       onClick={handleSubmit}
                     >

--- a/src/domain/signupGroup/testUtils.ts
+++ b/src/domain/signupGroup/testUtils.ts
@@ -21,6 +21,7 @@ export const getSignupFormElement = (
     | 'serviceLanguageButton'
     | 'streetAddressInput'
     | 'submitButton'
+    | 'updateButton'
     | 'updateParticipantAmountButton'
     | 'zipInput'
 ) => {
@@ -59,6 +60,8 @@ export const getSignupFormElement = (
       return screen.getByLabelText(/katuosoite/i);
     case 'submitButton':
       return screen.getByRole('button', { name: /jatka ilmoittautumiseen/i });
+    case 'updateButton':
+      return screen.getByRole('button', { name: /tallenna/i });
     case 'updateParticipantAmountButton':
       return screen.getByRole('button', { name: /päivitä/i });
     case 'zipInput':
@@ -67,32 +70,20 @@ export const getSignupFormElement = (
 };
 
 export const shouldRenderSignupFormFields = async () => {
-  const firstNameInput = await findFirstNameInput();
-  const lastNameInput = getSignupFormElement('lastNameInput');
-  const streetAddressInput = getSignupFormElement('streetAddressInput');
-  const dateOfBirthInput = getSignupFormElement('dateOfBirthInput');
-  const zipInput = getSignupFormElement('zipInput');
-  const cityInput = getSignupFormElement('cityInput');
-  const emailInput = getSignupFormElement('emailInput');
-  const phoneInput = getSignupFormElement('phoneInput');
-  const emailCheckbox = getSignupFormElement('emailCheckbox');
-  const phoneCheckbox = getSignupFormElement('phoneCheckbox');
-  const nativeLanguageButton = getSignupFormElement('nativeLanguageButton');
-  const serviceLanguageButton = getSignupFormElement('serviceLanguageButton');
+  await findFirstNameInput();
+  getSignupFormElement('lastNameInput');
+  getSignupFormElement('streetAddressInput');
+  getSignupFormElement('dateOfBirthInput');
+  getSignupFormElement('zipInput');
+  getSignupFormElement('cityInput');
+  getSignupFormElement('emailInput');
+  getSignupFormElement('phoneInput');
+  getSignupFormElement('emailCheckbox');
+  getSignupFormElement('phoneCheckbox');
+  getSignupFormElement('nativeLanguageButton');
+  getSignupFormElement('serviceLanguageButton');
   getSignupFormElement('cancelButton');
-
-  expect(firstNameInput.hasAttribute('readonly')).toBeTruthy();
-  expect(lastNameInput.hasAttribute('readonly')).toBeTruthy();
-  expect(streetAddressInput.hasAttribute('readonly')).toBeTruthy();
-  expect(dateOfBirthInput.hasAttribute('readonly')).toBeTruthy();
-  expect(zipInput.hasAttribute('readonly')).toBeTruthy();
-  expect(cityInput.hasAttribute('readonly')).toBeTruthy();
-  expect(emailInput.hasAttribute('readonly')).toBeTruthy();
-  expect(phoneInput.hasAttribute('readonly')).toBeTruthy();
-  expect(emailCheckbox).toBeDisabled();
-  expect(phoneCheckbox).toBeDisabled();
-  expect(nativeLanguageButton).toBeDisabled();
-  expect(serviceLanguageButton).toBeDisabled();
+  getSignupFormElement('updateButton');
 };
 
 export const tryToCancel = async () => {
@@ -108,4 +99,10 @@ export const tryToCancel = async () => {
     name: 'Peruuta ilmoittautuminen',
   });
   await user.click(cancelSignupButton);
+};
+
+export const tryToUpdate = async () => {
+  const user = userEvent.setup();
+  const updateButton = getSignupFormElement('updateButton');
+  await user.click(updateButton);
 };

--- a/src/domain/signupGroup/types.ts
+++ b/src/domain/signupGroup/types.ts
@@ -15,14 +15,12 @@ export type UpdateSignupGroupMutationInput = { id: string } & Omit<
   'reservation_code'
 >;
 
-export type CreateSignupGroupResponse = {
+export type CreateOrUpdateSignupGroupResponse = {
   extra_info: string;
   id: string;
   registration: string;
   signups: Signup[];
 };
-
-export type UpdateSignupGroupResponse = CreateSignupGroupResponse;
 
 export type SignupGroup = {
   created_at: stringOrNull;

--- a/src/domain/signupGroup/utils.ts
+++ b/src/domain/signupGroup/utils.ts
@@ -26,13 +26,12 @@ import {
 } from './constants';
 import {
   CreateSignupGroupMutationInput,
-  CreateSignupGroupResponse,
+  CreateOrUpdateSignupGroupResponse,
   SignupFields,
   SignupGroup,
   SignupGroupFormFields,
   SignupGroupQueryVariables,
   UpdateSignupGroupMutationInput,
-  UpdateSignupGroupResponse,
 } from './types';
 
 export const getSignupNotificationsCode = (
@@ -210,7 +209,7 @@ export const createSignupGroup = async ({
 }: {
   input: CreateSignupGroupMutationInput;
   session: ExtendedSession | null;
-}): Promise<CreateSignupGroupResponse> => {
+}): Promise<CreateOrUpdateSignupGroupResponse> => {
   try {
     const { data } = await callPost({
       data: JSON.stringify(input),
@@ -263,12 +262,12 @@ export const updateSignupGroup = async ({
 }: {
   input: UpdateSignupGroupMutationInput;
   session: ExtendedSession | null;
-}): Promise<UpdateSignupGroupResponse> => {
+}): Promise<CreateOrUpdateSignupGroupResponse> => {
   try {
     const { data } = await callPut({
       data: JSON.stringify(input),
       session,
-      url: signupGroupPathBuilder({ id: id as string }),
+      url: signupGroupPathBuilder({ id }),
     });
     return data;
   } catch (error) {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -5,6 +5,7 @@ body {
   --label-height: 1.75rem;
   --focus-outline-width: 3px;
   --focus-outline-color: var(--color-coat-of-arms);
+  --toastify-color-success: var(--color-success);
 
   padding: 0;
   margin: 0;

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -1,11 +1,7 @@
 @mixin focus-outline($offset: 0px, $color: var(--focus-outline-color)) {
   &:focus {
-    outline: var(--focus-outline-width) solid $color;
+    outline: var(--focus-outline-width) solid $color !important;
     outline-offset: $offset;
-
-    // &:not(:global(.focus-visible)) {
-    //   outline: none;
-    // }
   }
 }
 


### PR DESCRIPTION
## Description :sparkles:
Changes in UI components to support updating signup or signup group

This is one of the 5 PRs that replaced https://github.com/City-of-Helsinki/linkedregistrations-ui/pull/74. The purpose of these PRs is to implement pages to update signups and signup groups

PR Parts:
- Replace LoadingButton component with HDS Button (https://github.com/City-of-Helsinki/linkedregistrations-ui/pull/81)
- Move signup form test util functions to separate file (https://github.com/City-of-Helsinki/linkedregistrations-ui/pull/82)
- Move delete signup button to the page bottom (https://github.com/City-of-Helsinki/linkedregistrations-ui/pull/83)
- Util functions and queries to update signups and signups groups (https://github.com/City-of-Helsinki/linkedregistrations-ui/pull/84)
- **Changes in UI components to support updating signup or signup group**

## Partially closes
[LINK-1484](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1484)


[LINK-1484]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ