### PR TITLE
LINK-1619 | Update participant amount input value after deleting a signup

### DIFF
--- a/src/domain/signup/EditSignupPage.tsx
+++ b/src/domain/signup/EditSignupPage.tsx
@@ -59,7 +59,7 @@ const EditSignupPageWrapper: React.FC = () => {
   return (
     <LoadingSpinner isLoading={isLoadingSignup || isLoadingEventOrRegistration}>
       {event && registration && signup ? (
-        <SignupGroupFormProvider>
+        <SignupGroupFormProvider registration={registration}>
           <SignupServerErrorsProvider>
             <EditSignupPage
               event={event}

--- a/src/domain/signupGroup/CreateSignupGroupPage.tsx
+++ b/src/domain/signupGroup/CreateSignupGroupPage.tsx
@@ -62,7 +62,7 @@ const CreateSignupGroupPageWrapper: React.FC = () => {
   return (
     <LoadingSpinner isLoading={isLoading}>
       {registration && event ? (
-        <SignupGroupFormProvider>
+        <SignupGroupFormProvider registration={registration}>
           <SignupServerErrorsProvider>
             <CreateSignupGroupPage event={event} registration={registration} />
           </SignupServerErrorsProvider>

--- a/src/domain/signupGroup/EditSignupGroupPage.tsx
+++ b/src/domain/signupGroup/EditSignupGroupPage.tsx
@@ -63,7 +63,7 @@ const EditSignupGroupPageWrapper: React.FC = () => {
   return (
     <LoadingSpinner isLoading={isLoadingSignup || isLoadingEventOrRegistration}>
       {event && registration && signupGroup ? (
-        <SignupGroupFormProvider>
+        <SignupGroupFormProvider registration={registration}>
           <SignupServerErrorsProvider>
             <EditSignupGroupPage
               event={event}

--- a/src/domain/signupGroup/__tests__/CreateSignupGroupPage.test.tsx
+++ b/src/domain/signupGroup/__tests__/CreateSignupGroupPage.test.tsx
@@ -358,6 +358,7 @@ test('should delete participants by clicking delete participant button', async (
       screen.queryByRole('button', { name: 'Osallistuja 2' })
     ).not.toBeInTheDocument()
   );
+  expect(participantAmountInput).toHaveValue(1);
 });
 
 test('should show server errors when updating seats reservation fails', async () => {

--- a/src/domain/signupGroup/participantAmountSelector/ParticipantAmountSelector.tsx
+++ b/src/domain/signupGroup/participantAmountSelector/ParticipantAmountSelector.tsx
@@ -10,7 +10,6 @@ import {
   getAttendeeCapacityError,
   getMaxSeatsAmount,
 } from '../../registration/utils';
-import { getSeatsReservationData } from '../../reserveSeats/utils';
 import { SIGNUP_MODALS } from '../../signup/constants';
 import useSeatsReservationActions from '../../signup/hooks/useSeatsReservationActions';
 import { useSignupServerErrorsContext } from '../../signup/signupServerErrorsContext/hooks/useSignupServerErrorsContext';
@@ -32,7 +31,13 @@ const ParticipantAmountSelector: React.FC<Props> = ({
 }) => {
   const { t } = useTranslation(['signup', 'common']);
 
-  const { closeModal, openModal, setOpenModal } = useSignupGroupFormContext();
+  const {
+    closeModal,
+    openModal,
+    participantAmount,
+    setOpenModal,
+    setParticipantAmount,
+  } = useSignupGroupFormContext();
   const { setServerErrorItems, showServerErrors } =
     useSignupServerErrorsContext();
 
@@ -41,10 +46,6 @@ const ParticipantAmountSelector: React.FC<Props> = ({
   const [{ value: signups }, , { setValue: setSignups }] = useField<
     SignupFormFields[]
   >({ name: SIGNUP_GROUP_FIELDS.SIGNUPS });
-
-  const [participantAmount, setParticipantAmount] = useState(
-    Math.max(getSeatsReservationData(registration.id)?.seats ?? 0, 1)
-  );
 
   const handleParticipantAmountChange: React.ChangeEventHandler<
     HTMLInputElement
@@ -107,12 +108,12 @@ const ParticipantAmountSelector: React.FC<Props> = ({
       <div className={styles.participantAmountSelector}>
         <NumberInput
           id="participant-amount-field"
-          minusStepButtonAriaLabel={
-            t('common:numberInput.minusStepButtonAriaLabel') as string
-          }
-          plusStepButtonAriaLabel={
-            t('common:numberInput.plusStepButtonAriaLabel') as string
-          }
+          minusStepButtonAriaLabel={t(
+            'common:numberInput.minusStepButtonAriaLabel'
+          )}
+          plusStepButtonAriaLabel={t(
+            'common:numberInput.plusStepButtonAriaLabel'
+          )}
           disabled={disabled}
           errorText={attendeeCapacityError}
           invalid={!!attendeeCapacityError}

--- a/src/domain/signupGroup/participantAmountSelector/__tests__/ParticipantAmountSelector.test.tsx
+++ b/src/domain/signupGroup/participantAmountSelector/__tests__/ParticipantAmountSelector.test.tsx
@@ -23,7 +23,7 @@ import ParticipantAmountSelector from '../ParticipantAmountSelector';
 
 const renderComponent = () =>
   render(
-    <SignupGroupFormProvider>
+    <SignupGroupFormProvider registration={registration}>
       <SignupServerErrorsProvider>
         <Formik
           initialValues={{ signups: [{ ...SIGNUP_INITIAL_VALUES }] }}

--- a/src/domain/signupGroup/reservationTimer/__tests__/ReservationTimer.test.tsx
+++ b/src/domain/signupGroup/reservationTimer/__tests__/ReservationTimer.test.tsx
@@ -44,7 +44,7 @@ const renderComponent = (
   serverErrorProps?: Partial<SignupServerErrorsContextProps>
 ) =>
   render(
-    <SignupGroupFormProvider>
+    <SignupGroupFormProvider registration={registration}>
       <SignupServerErrorsContext.Provider
         value={{ ...defaultServerErrorsProps, ...serverErrorProps }}
       >

--- a/src/domain/signupGroup/signupGroupForm/signups/Signups.tsx
+++ b/src/domain/signupGroup/signupGroupForm/signups/Signups.tsx
@@ -14,6 +14,7 @@ import {
 import { useSignupServerErrorsContext } from '../../../signup/signupServerErrorsContext/hooks/useSignupServerErrorsContext';
 import { SIGNUP_GROUP_FIELDS } from '../../constants';
 import ConfirmDeleteParticipantModal from '../../modals/confirmDeleteSignupFromFormModal/ConfirmDeleteSignupFromFormModal';
+import { useSignupGroupFormContext } from '../../signupGroupFormContext/hooks/useSignupGroupFormContext';
 import { SignupFormFields } from '../../types';
 import { getNewSignups } from '../../utils';
 
@@ -40,6 +41,7 @@ const Signups: React.FC<Props> = ({
   const [openModalIndex, setOpenModalIndex] = useState<number | null>(null);
   const [saving, setSaving] = useState(false);
 
+  const { setParticipantAmount } = useSignupGroupFormContext();
   const { setServerErrorItems, showServerErrors } =
     useSignupServerErrorsContext();
 
@@ -80,7 +82,7 @@ const Signups: React.FC<Props> = ({
         });
 
         setSignups(newSignups);
-
+        setParticipantAmount(newSignups.length);
         setSeatsReservationData(registration.id, seatsReservation);
 
         setSaving(false);

--- a/src/domain/signupGroup/signupGroupForm/signups/signup/Signup.tsx
+++ b/src/domain/signupGroup/signupGroupForm/signups/signup/Signup.tsx
@@ -55,7 +55,7 @@ const Signup: React.FC<Props> = ({
       deleteButton={
         showDelete && !formDisabled ? (
           <button
-            aria-label={t('buttonDeleteSignup') as string}
+            aria-label={t('buttonDeleteSignup')}
             className={styles.deleteButton}
             onClick={onDelete}
             type="button"

--- a/src/domain/signupGroup/signupGroupFormContext/SignupGroupFormContext.tsx
+++ b/src/domain/signupGroup/signupGroupFormContext/SignupGroupFormContext.tsx
@@ -9,6 +9,8 @@ import React, {
 } from 'react';
 
 import useMountedState from '../../../hooks/useMountedState';
+import { Registration } from '../../registration/types';
+import { getSeatsReservationData } from '../../reserveSeats/utils';
 import { SIGNUP_MODALS } from '../../signup/constants';
 import PersonsAddedToWaitingListModal from '../modals/personsAddedToWaitingListModal/PersonsAddedToWaitingListModal';
 
@@ -16,8 +18,10 @@ export type SignupGroupFormContextProps = {
   closeModal: () => void;
   openModal: SIGNUP_MODALS | null;
   openParticipant: number | null;
+  participantAmount: number;
   setOpenModal: (state: SIGNUP_MODALS | null) => void;
   setOpenParticipant: (index: number | null) => void;
+  setParticipantAmount: (amount: number) => void;
   toggleOpenParticipant: (index: number) => void;
 };
 
@@ -25,10 +29,13 @@ export const SignupGroupFormContext = createContext<
   SignupGroupFormContextProps | undefined
 >(undefined);
 
-export const SignupGroupFormProvider: FC<PropsWithChildren> = ({
-  children,
-}) => {
+export const SignupGroupFormProvider: FC<
+  PropsWithChildren<{ registration: Registration }>
+> = ({ children, registration }) => {
   const [openParticipant, setOpenParticipant] = useState<number | null>(0);
+  const [participantAmount, setParticipantAmount] = useState(
+    Math.max(getSeatsReservationData(registration.id)?.seats ?? 0, 1)
+  );
 
   const [openModal, setOpenModal] = useMountedState<SIGNUP_MODALS | null>(null);
 
@@ -44,11 +51,19 @@ export const SignupGroupFormProvider: FC<PropsWithChildren> = ({
       closeModal: () => setOpenModal(null),
       openModal,
       openParticipant,
+      participantAmount,
       setOpenModal,
       setOpenParticipant,
+      setParticipantAmount,
       toggleOpenParticipant,
     }),
-    [openModal, openParticipant, setOpenModal, toggleOpenParticipant]
+    [
+      openModal,
+      openParticipant,
+      participantAmount,
+      setOpenModal,
+      toggleOpenParticipant,
+    ]
   );
 
   return (

--- a/src/domain/signupGroup/summaryPage/SummaryPage.tsx
+++ b/src/domain/signupGroup/summaryPage/SummaryPage.tsx
@@ -221,7 +221,7 @@ const SummaryPageWrapper: React.FC = () => {
   return (
     <LoadingSpinner isLoading={isLoading}>
       {event && registration ? (
-        <SignupGroupFormProvider>
+        <SignupGroupFormProvider registration={registration}>
           <SignupServerErrorsProvider>
             <SummaryPage event={event} registration={registration} />
           </SignupServerErrorsProvider>

--- a/src/utils/testUtils.tsx
+++ b/src/utils/testUtils.tsx
@@ -20,6 +20,7 @@ import React, { useMemo } from 'react';
 import wait from 'waait';
 
 import { testId } from '../common/components/loadingSpinner/LoadingSpinner';
+import { registration } from '../domain/registration/__mocks__/registration';
 import { SignupGroupFormProvider } from '../domain/signupGroup/signupGroupFormContext/SignupGroupFormContext';
 import { server } from '../tests/msw/server';
 import { ExtendedSession } from '../types';
@@ -123,7 +124,7 @@ export const getQueryWrapper = (session: ExtendedSession | null = null) => {
 
   const wrapper = ({ children }: { children: React.ReactNode }) => (
     <SessionProvider session={session}>
-      <SignupGroupFormProvider>
+      <SignupGroupFormProvider registration={registration}>
         <QueryClientProvider client={queryClient}>
           {children}
         </QueryClientProvider>


### PR DESCRIPTION
## Description
Move participant amount value to SignupGroupFormContext and update it after deleting a signup from the form

## Closes
[LINK-1619](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1619)

## Testing
1. Open create signup group page
2. Input at least 2 to the participant amount input and press update button
3. Delete one of the signups

Expected result:
Participant amount input value should be updated to match number of signups in the form

[LINK-1619]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ