### PR TITLE
LINK-1623 | Don't send sensitive data to Sentry

### DIFF
--- a/src/__tests__/Pages.test.tsx
+++ b/src/__tests__/Pages.test.tsx
@@ -139,6 +139,7 @@ const signupGroupValues: SignupGroupFormFields = {
 
 const mocks = [
   ...mockedLanguagesResponses,
+  mockedUserResponse,
   rest.get(`*/registration/${TEST_REGISTRATION_ID}/`, (req, res, ctx) =>
     res(ctx.status(200), ctx.json(registration))
   ),

--- a/src/domain/app/header/Header.tsx
+++ b/src/domain/app/header/Header.tsx
@@ -10,21 +10,15 @@ import useLocale from '../../../hooks/useLocale';
 import useSelectLanguage from '../../../hooks/useSelectLanguage';
 import { ExtendedSession } from '../../../types';
 import { getUserName } from '../../auth/utils';
-import { useUserQuery } from '../../user/query';
+import useUser from '../../user/hooks/useUser';
 import { ROUTES } from '../routes/constants';
 
 import styles from './header.module.scss';
 
 const Header: React.FC = () => {
   const { data: session } = useSession() as { data: ExtendedSession | null };
-  const userId = session?.user?.id ?? '';
   const linkedEventsApiToken = session?.apiTokens?.linkedevents;
-
-  const { data: user } = useUserQuery({
-    args: { username: userId },
-    options: { enabled: Boolean(userId && linkedEventsApiToken) },
-    session,
-  });
+  const { user } = useUser();
 
   const locale = useLocale();
   const router = useRouter();

--- a/src/domain/signup/__tests__/EditSignupPage.test.tsx
+++ b/src/domain/signup/__tests__/EditSignupPage.test.tsx
@@ -29,6 +29,7 @@ import {
   tryToCancel,
   tryToUpdate,
 } from '../../signupGroup/testUtils';
+import { mockedUserResponse } from '../../user/__mocks__/user';
 import { signup } from '../__mocks__/signup';
 import { TEST_SIGNUP_ID } from '../constants';
 import EditSignupPage from '../EditSignupPage';
@@ -53,6 +54,7 @@ test.skip('page is accessible', async () => {
 
 const defaultMocks = [
   ...mockedLanguagesResponses,
+  mockedUserResponse,
   rest.get(`*/registration/${TEST_REGISTRATION_ID}/`, (req, res, ctx) =>
     res(ctx.status(200), ctx.json(registration))
   ),

--- a/src/domain/signup/__tests__/utils.test.ts
+++ b/src/domain/signup/__tests__/utils.test.ts
@@ -5,11 +5,12 @@ import {
   SIGNUP_GROUP_INITIAL_VALUES,
 } from '../../signupGroup/constants';
 import { NOTIFICATION_TYPE, TEST_SIGNUP_ID } from '../constants';
-import { SignupQueryVariables } from '../types';
+import { SignupInput, SignupQueryVariables } from '../types';
 import {
   getSignupFields,
   getSignupGroupInitialValuesFromSignup,
   getUpdateSignupPayload,
+  omitSensitiveDataFromSignupPayload,
   signupPathBuilder,
 } from '../utils';
 
@@ -253,5 +254,48 @@ describe('getUpdateSignupPayload function', () => {
       street_address: streetAddress,
       zipcode,
     });
+  });
+});
+
+describe('omitSensitiveDataFromSignupPayload', () => {
+  it('should omit sensitive data from payload', () => {
+    const payload: SignupInput = {
+      city: 'Helsinki',
+      date_of_birth: '1999-10-10',
+      email: 'test@email.com',
+      extra_info: 'Signup entra info',
+      first_name: 'First name',
+      id: '1',
+      last_name: 'Last name',
+      membership_number: 'XYZ',
+      native_language: 'fi',
+      notifications: NOTIFICATION_TYPE.EMAIL,
+      phone_number: '0441234567',
+      responsible_for_group: true,
+      service_language: 'fi',
+      street_address: 'Address',
+      zipcode: '123456',
+    };
+
+    const filteredPayload = omitSensitiveDataFromSignupPayload(
+      payload
+    ) as SignupInput;
+    expect(filteredPayload).toEqual({
+      city: 'Helsinki',
+      id: '1',
+      membership_number: 'XYZ',
+      native_language: 'fi',
+      notifications: NOTIFICATION_TYPE.EMAIL,
+      responsible_for_group: true,
+      service_language: 'fi',
+      street_address: 'Address',
+      zipcode: '123456',
+    });
+    expect(filteredPayload.extra_info).toBeUndefined();
+    expect(filteredPayload.email).toBeUndefined();
+    expect(filteredPayload.extra_info).toBeUndefined();
+    expect(filteredPayload.first_name).toBeUndefined();
+    expect(filteredPayload.last_name).toBeUndefined();
+    expect(filteredPayload.phone_number).toBeUndefined();
   });
 });

--- a/src/domain/signup/hooks/useSignupActions.ts
+++ b/src/domain/signup/hooks/useSignupActions.ts
@@ -11,9 +11,13 @@ import { useDeleteSignupMutation, useUpdateSignupMutation } from '../mutation';
 import {
   DeleteSignupMutationInput,
   Signup,
+  SignupInput,
   UpdateSignupMutationInput,
 } from '../types';
-import { getUpdateSignupPayload } from '../utils';
+import {
+  getUpdateSignupPayload,
+  omitSensitiveDataFromSignupPayload,
+} from '../utils';
 
 interface Props {
   registration: Registration;
@@ -49,7 +53,9 @@ const useSignupActions = ({
   };
 
   const { handleError } = useHandleError<
-    DeleteSignupMutationInput | UpdateSignupMutationInput,
+    | DeleteSignupMutationInput
+    | Partial<UpdateSignupMutationInput>
+    | Partial<SignupInput>,
     Signup
   >();
 
@@ -102,8 +108,7 @@ const useSignupActions = ({
           callbacks,
           error,
           message: 'Failed to update signup',
-          object: signup,
-          payload: variables,
+          payload: omitSensitiveDataFromSignupPayload(variables),
           savingFinished,
         });
       },

--- a/src/domain/signup/utils.ts
+++ b/src/domain/signup/utils.ts
@@ -1,4 +1,5 @@
 import { AxiosError } from 'axios';
+import omit from 'lodash/omit';
 
 import { ExtendedSession } from '../../types';
 import formatDate from '../../utils/formatDate';
@@ -218,3 +219,14 @@ export const getSignupFields = ({
     lastName,
   };
 };
+export const omitSensitiveDataFromSignupPayload = (
+  payload: SignupInput | UpdateSignupMutationInput
+) =>
+  omit(payload, [
+    'date_of_birth',
+    'email',
+    'extra_info',
+    'first_name',
+    'last_name',
+    'phone_number',
+  ]);

--- a/src/domain/signupGroup/__tests__/CreateSignupGroupPage.test.tsx
+++ b/src/domain/signupGroup/__tests__/CreateSignupGroupPage.test.tsx
@@ -31,6 +31,7 @@ import { ROUTES } from '../../app/routes/constants';
 import { mockedLanguagesResponses } from '../../language/__mocks__/languages';
 import { registration } from '../../registration/__mocks__/registration';
 import { TEST_REGISTRATION_ID } from '../../registration/constants';
+import { mockedUserResponse } from '../../user/__mocks__/user';
 import CreateSignupGroupPage from '../CreateSignupGroupPage';
 import { findFirstNameInput, getSignupFormElement } from '../testUtils';
 
@@ -68,6 +69,7 @@ beforeEach(() => {
 
 const defaultMocks = [
   ...mockedLanguagesResponses,
+  mockedUserResponse,
   rest.get(`*/registration/${TEST_REGISTRATION_ID}/`, (req, res, ctx) =>
     res(ctx.status(200), ctx.json(registration))
   ),

--- a/src/domain/signupGroup/__tests__/EditSignupGroupPage.test.tsx
+++ b/src/domain/signupGroup/__tests__/EditSignupGroupPage.test.tsx
@@ -23,6 +23,7 @@ import { ROUTES } from '../../app/routes/constants';
 import { mockedLanguagesResponses } from '../../language/__mocks__/languages';
 import { registration } from '../../registration/__mocks__/registration';
 import { TEST_REGISTRATION_ID } from '../../registration/constants';
+import { mockedUserResponse } from '../../user/__mocks__/user';
 import { signupGroup } from '../__mocks__/signupGroup';
 import { TEST_SIGNUP_GROUP_ID } from '../constants';
 import EditSignupGroupPage from '../EditSignupGroupPage';
@@ -53,6 +54,7 @@ test.skip('page is accessible', async () => {
 
 const defaultMocks = [
   ...mockedLanguagesResponses,
+  mockedUserResponse,
   rest.get(`*/registration/${TEST_REGISTRATION_ID}/`, (req, res, ctx) =>
     res(ctx.status(200), ctx.json(registration))
   ),

--- a/src/domain/signupGroup/__tests__/utils.test.ts
+++ b/src/domain/signupGroup/__tests__/utils.test.ts
@@ -16,7 +16,10 @@ import {
   SIGNUP_INITIAL_VALUES,
   TEST_SIGNUP_GROUP_ID,
 } from '../constants';
-import { SignupGroupQueryVariables } from '../types';
+import {
+  CreateSignupGroupMutationInput,
+  SignupGroupQueryVariables,
+} from '../types';
 import {
   getSignupDefaultInitialValues,
   getSignupGroupDefaultInitialValues,
@@ -25,6 +28,7 @@ import {
   getSignupNotificationTypes,
   getSignupNotificationsCode,
   getUpdateSignupGroupPayload,
+  omitSensitiveDataFromSignupGroupPayload,
   isSignupFieldRequired,
   signupGroupPathBuilder,
 } from '../utils';
@@ -534,5 +538,61 @@ describe('getUpdateSignupGroupPayload function', () => {
         },
       ],
     });
+  });
+});
+
+describe('omitSensitiveDataFromSignupGroupPayload', () => {
+  it('should omit sensitive data from payload', () => {
+    const payload: CreateSignupGroupMutationInput = {
+      extra_info: 'Extra info',
+      registration: registration.id,
+      reservation_code: 'xxx',
+      signups: [
+        {
+          city: 'Helsinki',
+          date_of_birth: '1999-10-10',
+          email: 'test@email.com',
+          extra_info: 'Signup entra info',
+          first_name: 'First name',
+          id: '1',
+          last_name: 'Last name',
+          membership_number: 'XYZ',
+          native_language: 'fi',
+          notifications: NOTIFICATION_TYPE.EMAIL,
+          phone_number: '0441234567',
+          responsible_for_group: true,
+          service_language: 'fi',
+          street_address: 'Address',
+          zipcode: '123456',
+        },
+      ],
+    };
+
+    const filteredPayload = omitSensitiveDataFromSignupGroupPayload(
+      payload
+    ) as CreateSignupGroupMutationInput;
+    expect(filteredPayload).toEqual({
+      registration: registration.id,
+      reservation_code: 'xxx',
+      signups: [
+        {
+          city: 'Helsinki',
+          id: '1',
+          membership_number: 'XYZ',
+          native_language: 'fi',
+          notifications: NOTIFICATION_TYPE.EMAIL,
+          responsible_for_group: true,
+          service_language: 'fi',
+          street_address: 'Address',
+          zipcode: '123456',
+        },
+      ],
+    });
+    expect(filteredPayload.extra_info).toBeUndefined();
+    expect(filteredPayload.signups[0].email).toBeUndefined();
+    expect(filteredPayload.signups[0].extra_info).toBeUndefined();
+    expect(filteredPayload.signups[0].first_name).toBeUndefined();
+    expect(filteredPayload.signups[0].last_name).toBeUndefined();
+    expect(filteredPayload.signups[0].phone_number).toBeUndefined();
   });
 });

--- a/src/domain/signupGroup/hooks/useSignupGroupActions.ts
+++ b/src/domain/signupGroup/hooks/useSignupGroupActions.ts
@@ -19,7 +19,11 @@ import {
   SignupGroupFormFields,
   UpdateSignupGroupMutationInput,
 } from '../types';
-import { getSignupGroupPayload, getUpdateSignupGroupPayload } from '../utils';
+import {
+  getSignupGroupPayload,
+  getUpdateSignupGroupPayload,
+  omitSensitiveDataFromSignupGroupPayload,
+} from '../utils';
 
 interface Props {
   registration: Registration;
@@ -63,7 +67,7 @@ const useSignupGroupActions = ({
   };
 
   const { handleError } = useHandleError<
-    CreateSignupGroupMutationInput | DeleteSignupGroupMutationInput,
+    Partial<CreateSignupGroupMutationInput> | DeleteSignupGroupMutationInput,
     SignupGroup
   >();
 
@@ -95,7 +99,7 @@ const useSignupGroupActions = ({
           callbacks,
           error,
           message: 'Failed to create signup group',
-          payload: variables,
+          payload: omitSensitiveDataFromSignupGroupPayload(variables),
           savingFinished,
         });
       },
@@ -118,7 +122,6 @@ const useSignupGroupActions = ({
             callbacks,
             error,
             message: 'Failed to delete signup',
-            object: signupGroup,
             payload: variables,
             savingFinished,
           });
@@ -152,8 +155,7 @@ const useSignupGroupActions = ({
           callbacks,
           error,
           message: 'Failed to update signup group',
-          object: signupGroup,
-          payload: variables,
+          payload: omitSensitiveDataFromSignupGroupPayload(variables),
           savingFinished,
         });
       },

--- a/src/domain/signupGroup/reservationTimer/__tests__/ReservationTimer.test.tsx
+++ b/src/domain/signupGroup/reservationTimer/__tests__/ReservationTimer.test.tsx
@@ -27,6 +27,7 @@ import {
   SignupServerErrorsContext,
   SignupServerErrorsContextProps,
 } from '../../../signup/signupServerErrorsContext/SignupServerErrorsContext';
+import { mockedUserResponse } from '../../../user/__mocks__/user';
 import { SignupGroupFormProvider } from '../../signupGroupFormContext/SignupGroupFormContext';
 import ReservationTimer from '../ReservationTimer';
 
@@ -74,6 +75,7 @@ test('should show server errors when creating seats reservation fails', async ()
   const showServerErrors = jest.fn();
 
   setQueryMocks(
+    mockedUserResponse,
     rest.post(`*/seats_reservation/`, (req, res, ctx) =>
       res(ctx.status(400), ctx.json({}))
     )
@@ -92,6 +94,7 @@ test('should show server errors when creating seats reservation fails', async ()
 test('should show modal if reserved seats are in waiting list', async () => {
   const user = userEvent.setup();
   setQueryMocks(
+    mockedUserResponse,
     rest.post(`*/seats_reservation/`, (req, res, ctx) =>
       res(
         ctx.status(201),
@@ -122,6 +125,7 @@ test('should route to create signup group page if reservation is expired', async
     seatsReservation: getMockedSeatsReservationData(-1000),
   });
 
+  setQueryMocks(mockedUserResponse);
   singletonRouter.push({
     pathname: ROUTES.CREATE_SIGNUP_GROUP_SUMMARY,
     query: { registrationId: registration.id },
@@ -155,6 +159,7 @@ test('should reload page if reservation is expired and route is create signup gr
     seatsReservation: getMockedSeatsReservationData(-1000),
   });
 
+  setQueryMocks(mockedUserResponse);
   singletonRouter.push({
     pathname: ROUTES.CREATE_SIGNUP_GROUP,
     query: { registrationId: registration.id },

--- a/src/domain/signupGroup/summaryPage/__tests__/SummaryPage.test.tsx
+++ b/src/domain/signupGroup/summaryPage/__tests__/SummaryPage.test.tsx
@@ -28,6 +28,7 @@ import { ROUTES } from '../../../app/routes/constants';
 import { mockedLanguagesResponses } from '../../../language/__mocks__/languages';
 import { registration } from '../../../registration/__mocks__/registration';
 import { TEST_REGISTRATION_ID } from '../../../registration/constants';
+import { mockedUserResponse } from '../../../user/__mocks__/user';
 import { NOTIFICATIONS, TEST_SIGNUP_GROUP_ID } from '../../constants';
 import { SignupGroupFormFields } from '../../types';
 import SummaryPage from '../SummaryPage';
@@ -79,6 +80,7 @@ const signupGroupValues: SignupGroupFormFields = {
 
 const defaultMocks = [
   ...mockedLanguagesResponses,
+  mockedUserResponse,
   rest.get(`*/registration/${TEST_REGISTRATION_ID}/`, (req, res, ctx) =>
     res(ctx.status(200), ctx.json(registration))
   ),

--- a/src/domain/signupGroup/utils.ts
+++ b/src/domain/signupGroup/utils.ts
@@ -1,5 +1,6 @@
 import { AxiosError } from 'axios';
 import isEqual from 'lodash/isEqual';
+import omit from 'lodash/omit';
 import snakeCase from 'lodash/snakeCase';
 
 import { FORM_NAMES } from '../../constants';
@@ -15,7 +16,11 @@ import { Registration } from '../registration/types';
 import { SeatsReservation } from '../reserveSeats/types';
 import { ATTENDEE_STATUS, NOTIFICATION_TYPE } from '../signup/constants';
 import { Signup, SignupInput } from '../signup/types';
-import { getSignupInitialValues, getSignupPayload } from '../signup/utils';
+import {
+  getSignupInitialValues,
+  getSignupPayload,
+  omitSensitiveDataFromSignupPayload,
+} from '../signup/utils';
 
 import {
   NOTIFICATIONS,
@@ -281,3 +286,10 @@ export const updateSignupGroup = async ({
     throw Error(JSON.stringify((error as AxiosError).response?.data));
   }
 };
+
+export const omitSensitiveDataFromSignupGroupPayload = (
+  payload: CreateSignupGroupMutationInput | UpdateSignupGroupMutationInput
+) => ({
+  ...omit(payload, ['extra_info']),
+  signups: payload.signups.map((s) => omitSensitiveDataFromSignupPayload(s)),
+});

--- a/src/domain/user/hooks/useUser.ts
+++ b/src/domain/user/hooks/useUser.ts
@@ -1,0 +1,38 @@
+import { useSession } from 'next-auth/react';
+import { useMemo } from 'react';
+
+import { ExtendedSession } from '../../../types';
+import { useUserQuery } from '../query';
+import { User } from '../types';
+
+export type UserState = {
+  loading: boolean;
+  user?: User;
+};
+
+const useUser = (): UserState => {
+  const { data: session } = useSession() as { data: ExtendedSession | null };
+  const userId = session?.user?.id ?? '';
+  const linkedEventsApiToken = session?.apiTokens?.linkedevents;
+
+  const {
+    data: user,
+    isFetching,
+    status,
+  } = useUserQuery({
+    args: { username: userId },
+    options: { enabled: Boolean(userId && linkedEventsApiToken) },
+    session,
+  });
+
+  const state = useMemo(
+    () => ({
+      user,
+      loading: status === 'loading' && isFetching,
+    }),
+    [isFetching, status, user]
+  );
+  return state;
+};
+
+export default useUser;

--- a/src/hooks/__tests__/useHandleError.test.ts
+++ b/src/hooks/__tests__/useHandleError.test.ts
@@ -1,0 +1,54 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as Sentry from '@sentry/browser';
+import { act, renderHook } from '@testing-library/react';
+import { advanceTo, clear } from 'jest-date-mock';
+
+import { mockedUserResponse, user } from '../../domain/user/__mocks__/user';
+import useUser from '../../domain/user/hooks/useUser';
+import { fakeAuthenticatedSession } from '../../utils/mockSession';
+import { getQueryWrapper, setQueryMocks, waitFor } from '../../utils/testUtils';
+import useHandleError from '../useHandleError';
+
+afterEach(() => {
+  clear();
+});
+
+describe('useHandleError', () => {
+  it('should call savingFinished when handling error finished', async () => {
+    advanceTo('2023-01-01');
+    (Sentry as any).captureException = jest.fn();
+    const savingFinished = jest.fn();
+    setQueryMocks(mockedUserResponse);
+    const wrapper = getQueryWrapper(fakeAuthenticatedSession());
+    const { result: userResult } = renderHook(() => useUser(), {
+      wrapper,
+    });
+    const { result } = renderHook(() => useHandleError(), {
+      wrapper,
+    });
+    await waitFor(() => expect(userResult.current.user).toEqual(user));
+    await act(
+      async () =>
+        await result.current.handleError({
+          error: new Error(),
+          message: 'Failed to save',
+          savingFinished,
+        })
+    );
+    await waitFor(() =>
+      expect(Sentry.captureException).toBeCalledWith('Failed to save', {
+        extra: {
+          data: expect.objectContaining({
+            currentUrl: 'http://localhost/',
+            errorAsString: '{}',
+            object: undefined,
+            payloadAsString: undefined,
+            timestamp: new Date('2023-01-01T00:00:00.000Z'),
+            user: user.username,
+          }),
+          level: 'error',
+        },
+      })
+    );
+  });
+});

--- a/src/hooks/useHandleError.ts
+++ b/src/hooks/useHandleError.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { reportError } from '../domain/app/sentry/utils';
+import useUser from '../domain/user/hooks/useUser';
 import { MutationCallbacks } from '../types';
 
 type UseHandleErrorState<PayloadType, ObjectType> = {
@@ -25,6 +26,7 @@ function useHandleError<PayloadType, ObjectType>(): UseHandleErrorState<
   PayloadType,
   ObjectType
 > {
+  const { user } = useUser();
   const handleError = ({
     callbacks,
     error,
@@ -49,6 +51,7 @@ function useHandleError<PayloadType, ObjectType>(): UseHandleErrorState<
         error,
         payloadAsString: payload && JSON.stringify(payload),
         object,
+        user: user?.username,
       },
       message,
     });


### PR DESCRIPTION
## Description :sparkles:
- Don't send signup group `extra_info` or signup `date_of_birth`, `email`, `extra_info`, `first_name`, `last_name` or `phone_number` to Sentry,
- Inject username of user instance to each Sentry error report

## Issues :bug:
[LINK-1623](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1623)

[LINK-1623]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ