### PR TITLE
LINK-1602 | Replace react-toastify with HDS Notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "react-dom": "18.2.0",
     "react-i18next": "^13.2.2",
     "react-scroll": "^1.8.9",
-    "react-toastify": "^9.1.3",
     "sass": "^1.66.1",
     "use-debounce": "^9.0.4",
     "yup": "^1.2.0"

--- a/src/common/components/notification/Notification.tsx
+++ b/src/common/components/notification/Notification.tsx
@@ -1,0 +1,29 @@
+import classNames from 'classnames';
+import {
+  Notification as HdsNotification,
+  NotificationProps as HdsNotificationProps,
+} from 'hds-react';
+import React from 'react';
+
+import styles from './notification.module.scss';
+
+export type NotificationProps = { id?: string } & HdsNotificationProps;
+
+const Notification: React.FC<NotificationProps> = ({
+  className,
+  id,
+  type = 'success',
+  ...rest
+}) => {
+  return (
+    <div id={id}>
+      <HdsNotification
+        {...rest}
+        className={classNames(styles.notification, className)}
+        type={type}
+      />
+    </div>
+  );
+};
+
+export default Notification;

--- a/src/common/components/notification/notification.module.scss
+++ b/src/common/components/notification/notification.module.scss
@@ -1,0 +1,3 @@
+.notification {
+  --notification-z-index-toast: 10 !important;
+}

--- a/src/common/components/notificationsContext/NotificationsContext.tsx
+++ b/src/common/components/notificationsContext/NotificationsContext.tsx
@@ -1,0 +1,81 @@
+import uniqueId from 'lodash/uniqueId';
+import React, {
+  createContext,
+  FC,
+  PropsWithChildren,
+  useMemo,
+  useState,
+} from 'react';
+
+import Notification, { NotificationProps } from '../notification/Notification';
+
+export type NotificationsContextProps = {
+  addNotification: (props: NotificationProps) => void;
+};
+
+export const NotificationsContext = createContext<
+  NotificationsContextProps | undefined
+>(undefined);
+
+export const NotificationsProvider: FC<PropsWithChildren> = ({ children }) => {
+  const [notifications, setNotifications] = useState<NotificationProps[]>([]);
+
+  const value = useMemo<NotificationsContextProps>(() => {
+    return {
+      addNotification: (props: NotificationProps) =>
+        setNotifications((items) => [
+          ...items,
+          { ...props, id: uniqueId('notification-') },
+        ]),
+    };
+  }, [setNotifications]);
+
+  const heights = useMemo(
+    () =>
+      // Height of last added notification is 0 because it's not rendered yet.
+      // In this case it doesn't matter because it's not used for top-margin calculation
+      notifications.map(
+        ({ id }) =>
+          document.getElementById(id as string)?.children[0]?.clientHeight ?? 0
+      ),
+    [notifications]
+  );
+
+  return (
+    <NotificationsContext.Provider value={value}>
+      {notifications.map((props, index) => {
+        const removeNotification = () =>
+          setNotifications((items) => items.filter((i) => i.id !== props.id));
+        const getNotificationStyle = (): React.CSSProperties => {
+          const offset = 32;
+          const topMargin = heights
+            .slice(0, -(notifications.length - index))
+            .reduce((acc, curr) => acc + curr + offset, offset);
+
+          return {
+            top: topMargin,
+            zIndex: 1000,
+          };
+        };
+        return (
+          <Notification
+            notificationAriaLabel={
+              typeof props.label === 'string'
+                ? props.label
+                : /* istanbul ignore next */
+                  undefined
+            }
+            {...props}
+            style={getNotificationStyle()}
+            key={props.id}
+            size="default"
+            position="top-right"
+            autoClose={true}
+            onClose={removeNotification}
+          />
+        );
+      })}
+      {children}
+    </NotificationsContext.Provider>
+  );
+};

--- a/src/common/components/notificationsContext/__tests__/NotificationsContext.test.tsx
+++ b/src/common/components/notificationsContext/__tests__/NotificationsContext.test.tsx
@@ -1,0 +1,58 @@
+import { configure, render, screen, waitFor } from '@testing-library/react';
+import React, { useEffect } from 'react';
+
+import { useNotificationsContext } from '../hooks/useNotificationsContext';
+import { NotificationsProvider } from '../NotificationsContext';
+
+configure({ defaultHidden: true });
+
+it('should show several notifications', async () => {
+  const Component = () => {
+    const { addNotification } = useNotificationsContext();
+
+    useEffect(() => {
+      addNotification({ label: 'Notification 1', type: 'success' });
+      addNotification({ label: 'Notification 2', type: 'error' });
+      addNotification({ label: 'Notification 3', type: 'info' });
+    });
+    return null;
+  };
+
+  render(
+    <NotificationsProvider>
+      <Component />
+    </NotificationsProvider>
+  );
+
+  await screen.findByRole('alert', { name: 'Notification 1' });
+  await screen.findByRole('alert', { name: 'Notification 2' });
+  await screen.findByRole('alert', { name: 'Notification 3' });
+});
+
+it('should automatically hide notification after certain period of time', async () => {
+  const Component = () => {
+    const { addNotification } = useNotificationsContext();
+
+    useEffect(() => {
+      addNotification({
+        autoCloseDuration: 50,
+        label: 'Notification 1',
+        type: 'success',
+      });
+    });
+    return null;
+  };
+
+  render(
+    <NotificationsProvider>
+      <Component />
+    </NotificationsProvider>
+  );
+
+  await screen.findByRole('alert', { name: 'Notification 1' });
+  await waitFor(() =>
+    expect(
+      screen.queryByRole('alert', { name: 'Notification 1' })
+    ).not.toBeInTheDocument()
+  );
+});

--- a/src/common/components/notificationsContext/hooks/useNotificationsContext.ts
+++ b/src/common/components/notificationsContext/hooks/useNotificationsContext.ts
@@ -1,0 +1,23 @@
+/* eslint @typescript-eslint/explicit-function-return-type: 0 */
+import { useContext } from 'react';
+
+import {
+  NotificationsContext,
+  NotificationsContextProps,
+} from '../NotificationsContext';
+
+export const useNotificationsContext = (): NotificationsContextProps => {
+  const context = useContext<NotificationsContextProps | undefined>(
+    NotificationsContext
+  );
+
+  /* istanbul ignore next */
+  if (!context) {
+    throw new Error(
+      // eslint-disable-next-line max-len
+      'NotificationsContext context is undefined, please verify you are calling useNotificationsContext() as child of a <NotificationsProvider> component.'
+    );
+  }
+
+  return context;
+};

--- a/src/domain/attendanceList/__tests__/AttendanceListPage.test.tsx
+++ b/src/domain/attendanceList/__tests__/AttendanceListPage.test.tsx
@@ -4,7 +4,6 @@ import { rest } from 'msw';
 import singletonRouter from 'next/router';
 import * as nextAuth from 'next-auth/react';
 import React from 'react';
-import { toast } from 'react-toastify';
 
 import { ExtendedSession } from '../../../types';
 import { fakeAuthenticatedSession } from '../../../utils/mockSession';
@@ -155,7 +154,6 @@ test('should mark signup as present', async () => {
 });
 
 test('should show toast message if updating presence status fails', async () => {
-  toast.error = jest.fn();
   const user = userEvent.setup();
 
   setQueryMocks(
@@ -173,11 +171,9 @@ test('should show toast message if updating presence status fails', async () => 
 
   const signupCheckbox = screen.getByRole('checkbox', { name: signUpName });
   user.click(signupCheckbox);
-  await waitFor(() =>
-    expect(toast.error).toBeCalledWith(
-      'Läsnäolotiedon päivittäminen epäonnistui'
-    )
-  );
+  await screen.findByRole('alert', {
+    name: 'Läsnäolotiedon päivittäminen epäonnistui',
+  });
 });
 
 test('should show authentication required page if user is not authenticated', async () => {

--- a/src/domain/attendanceList/attendeeList/AttendeeList.tsx
+++ b/src/domain/attendanceList/attendeeList/AttendeeList.tsx
@@ -3,9 +3,9 @@ import orderBy from 'lodash/orderBy';
 import { useSession } from 'next-auth/react';
 import { useTranslation } from 'next-i18next';
 import React, { useState } from 'react';
-import { toast } from 'react-toastify';
 
 import Checkbox from '../../../common/components/checkbox/Checkbox';
+import { useNotificationsContext } from '../../../common/components/notificationsContext/hooks/useNotificationsContext';
 import SearchRow from '../../../common/components/searchRow/SearchRow';
 import useHandleError from '../../../hooks/useHandleError';
 import { ExtendedSession } from '../../../types';
@@ -26,6 +26,8 @@ const AttendeeList: React.FC<Props> = ({ registration }) => {
 
   const [saving, setSaving] = useState(false);
   const [search, setSearch] = useState('');
+
+  const { addNotification } = useNotificationsContext();
 
   const queryClient = useQueryClient();
   const { data: session } = useSession() as { data: ExtendedSession | null };
@@ -77,7 +79,10 @@ const AttendeeList: React.FC<Props> = ({ registration }) => {
           object: signup,
           savingFinished,
         });
-        toast.error(t('attendanceList:errors.presenceStatusUpdateFails'));
+        addNotification({
+          type: 'error',
+          label: t('attendanceList:errors.presenceStatusUpdateFails'),
+        });
       },
       onSuccess: (data) => {
         queryClient.setQueryData(

--- a/src/domain/signup/__tests__/EditSignupPage.test.tsx
+++ b/src/domain/signup/__tests__/EditSignupPage.test.tsx
@@ -6,7 +6,6 @@ import singletonRouter from 'next/router';
 import * as nextAuth from 'next-auth/react';
 import mockRouter from 'next-router-mock';
 import React from 'react';
-import { toast } from 'react-toastify';
 
 import { ExtendedSession } from '../../../types';
 import { fakeAuthenticatedSession } from '../../../utils/mockSession';
@@ -123,7 +122,6 @@ test('should show error message when cancelling signup fails', async () => {
 });
 
 test('should update signup', async () => {
-  toast.success = jest.fn();
   setQueryMocks(
     ...defaultMocks,
     rest.put(`*/signup/${TEST_SIGNUP_ID}`, (req, res, ctx) =>
@@ -136,9 +134,9 @@ test('should update signup', async () => {
   await findFirstNameInput();
   await tryToUpdate();
 
-  await waitFor(() =>
-    expect(toast.success).toBeCalledWith('Osallistujan tiedot on tallennettu')
-  );
+  await screen.findByRole('alert', {
+    name: 'Osallistujan tiedot on tallennettu',
+  });
 });
 
 test('should show error message when updating signup fails', async () => {

--- a/src/domain/signupGroup/__tests__/EditSignupGroupPage.test.tsx
+++ b/src/domain/signupGroup/__tests__/EditSignupGroupPage.test.tsx
@@ -6,7 +6,6 @@ import singletonRouter from 'next/router';
 import * as nextAuth from 'next-auth/react';
 import mockRouter from 'next-router-mock';
 import React from 'react';
-import { toast } from 'react-toastify';
 
 import { ExtendedSession } from '../../../types';
 import { fakeAuthenticatedSession } from '../../../utils/mockSession';
@@ -123,7 +122,6 @@ test('should show error message when cancelling signup group fails', async () =>
 });
 
 test('should update signup group', async () => {
-  toast.success = jest.fn();
   setQueryMocks(
     ...defaultMocks,
     rest.put(`*/signup_group/${TEST_SIGNUP_GROUP_ID}`, (req, res, ctx) =>
@@ -136,9 +134,9 @@ test('should update signup group', async () => {
   await findFirstNameInput();
   await tryToUpdate();
 
-  await waitFor(() =>
-    expect(toast.success).toBeCalledWith('Osallistujien tiedot on tallennettu')
-  );
+  await screen.findByRole('alert', {
+    name: 'Osallistujien tiedot on tallennettu',
+  });
 });
 
 test('should show error message when updating signup group fails', async () => {

--- a/src/domain/signupGroup/authenticationRequiredNotification/AuthenticationRequiredNotification.tsx
+++ b/src/domain/signupGroup/authenticationRequiredNotification/AuthenticationRequiredNotification.tsx
@@ -1,9 +1,9 @@
-import { Notification } from 'hds-react';
 import { signIn } from 'next-auth/react';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 
 import Button from '../../../common/components/button/Button';
+import Notification from '../../../common/components/notification/Notification';
 
 import styles from './authenticationRequiredNotification.module.scss';
 

--- a/src/domain/signupGroup/registrationWarning/RegistrationWarning.tsx
+++ b/src/domain/signupGroup/registrationWarning/RegistrationWarning.tsx
@@ -1,7 +1,7 @@
-import { Notification } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import React, { useMemo } from 'react';
 
+import Notification from '../../../common/components/notification/Notification';
 import { Registration } from '../../registration/types';
 import { getRegistrationWarning } from '../../registration/utils';
 import {

--- a/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
+++ b/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
@@ -5,9 +5,7 @@ import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import React, { useMemo } from 'react';
-import { toast } from 'react-toastify';
 import { ValidationError } from 'yup';
-import 'react-toastify/dist/ReactToastify.css';
 
 import Button from '../../../common/components/button/Button';
 import Fieldset from '../../../common/components/fieldset/Fieldset';
@@ -19,6 +17,7 @@ import TextAreaField from '../../../common/components/formFields/TextAreaField';
 import TextInputField from '../../../common/components/formFields/TextInputField';
 import FormGroup from '../../../common/components/formGroup/FormGroup';
 import FormikPersist from '../../../common/components/formikPersist/FormikPersist';
+import { useNotificationsContext } from '../../../common/components/notificationsContext/hooks/useNotificationsContext';
 import ServerErrorSummary from '../../../common/components/serverErrorSummary/ServerErrorSummary';
 import { FORM_NAMES } from '../../../constants';
 import useLocale from '../../../hooks/useLocale';
@@ -106,6 +105,8 @@ const SignupGroupForm: React.FC<Props> = ({
     signupGroup,
   });
   const formSavingDisabled = React.useRef(isEditingMode);
+
+  const { addNotification } = useNotificationsContext();
 
   const reservationTimerCallbacksDisabled = React.useRef(false);
   const disableReservationTimerCallbacks = React.useCallback(() => {
@@ -195,7 +196,10 @@ const SignupGroupForm: React.FC<Props> = ({
           showServerErrors({ error: JSON.parse(error.message) }, 'signup'),
         onSuccess: () => {
           window.scrollTo(0, 0);
-          toast.success(t('signup:notificationSignupGroupUpdated'));
+          addNotification({
+            type: 'success',
+            label: t('signup:notificationSignupGroupUpdated'),
+          });
         },
       });
     } else {
@@ -204,7 +208,10 @@ const SignupGroupForm: React.FC<Props> = ({
           showServerErrors({ error: JSON.parse(error.message) }, 'signup'),
         onSuccess: () => {
           window.scrollTo(0, 0);
-          toast.success(t('signup:notificationSignupUpdated'));
+          addNotification({
+            type: 'success',
+            label: t('signup:notificationSignupUpdated'),
+          });
         },
       });
     }

--- a/src/domain/signupGroup/summaryPage/SummaryPage.tsx
+++ b/src/domain/signupGroup/summaryPage/SummaryPage.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import { Form, Formik } from 'formik';
-import { IconPen, Notification } from 'hds-react';
+import { IconPen } from 'hds-react';
 import pick from 'lodash/pick';
 import { useRouter } from 'next/router';
 import { useSession } from 'next-auth/react';
@@ -11,6 +11,7 @@ import Button from '../../../common/components/button/Button';
 import ButtonPanel from '../../../common/components/buttonPanel/ButtonPanel';
 import FormikPersist from '../../../common/components/formikPersist/FormikPersist';
 import LoadingSpinner from '../../../common/components/loadingSpinner/LoadingSpinner';
+import Notification from '../../../common/components/notification/Notification';
 import ServerErrorSummary from '../../../common/components/serverErrorSummary/ServerErrorSummary';
 import { FORM_NAMES } from '../../../constants';
 import { ExtendedSession } from '../../../types';

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import 'hds-core/lib/base.min.css';
 import '../styles/main.scss';
-import 'react-toastify/dist/ReactToastify.css';
 
 import {
   Hydrate,
@@ -13,8 +12,8 @@ import { Session } from 'next-auth';
 import { SessionProvider } from 'next-auth/react';
 import { appWithTranslation, SSRConfig } from 'next-i18next';
 import React from 'react';
-import { ToastContainer } from 'react-toastify';
 
+import { NotificationsProvider } from '../common/components/notificationsContext/NotificationsContext';
 import CookieConsent from '../domain/app/cookieConsent/CookieConsent';
 import PageLayout from '../domain/app/layout/pageLayout/PageLayout';
 
@@ -30,17 +29,21 @@ const MyApp = ({
   const [queryClient] = React.useState(() => new QueryClient());
 
   return (
-    <SessionProvider session={session} refetchInterval={/* 5 minutes */ 5 * 60}>
-      <QueryClientProvider client={queryClient}>
-        <Hydrate state={pageProps.dehydratedState}>
-          <CookieConsent />
-          <ToastContainer hideProgressBar={true} theme="colored" />
-          <PageLayout {...pageProps}>
-            <Component {...pageProps} />
-          </PageLayout>
-        </Hydrate>
-      </QueryClientProvider>
-    </SessionProvider>
+    <NotificationsProvider>
+      <SessionProvider
+        session={session}
+        refetchInterval={/* 5 minutes */ 5 * 60}
+      >
+        <QueryClientProvider client={queryClient}>
+          <Hydrate state={pageProps.dehydratedState}>
+            <CookieConsent />
+            <PageLayout {...pageProps}>
+              <Component {...pageProps} />
+            </PageLayout>
+          </Hydrate>
+        </QueryClientProvider>
+      </SessionProvider>
+    </NotificationsProvider>
   );
 };
 

--- a/src/utils/testUtils.tsx
+++ b/src/utils/testUtils.tsx
@@ -20,6 +20,7 @@ import React, { useMemo } from 'react';
 import wait from 'waait';
 
 import { testId } from '../common/components/loadingSpinner/LoadingSpinner';
+import { NotificationsProvider } from '../common/components/notificationsContext/NotificationsContext';
 import { registration } from '../domain/registration/__mocks__/registration';
 import { SignupGroupFormProvider } from '../domain/signupGroup/signupGroupFormContext/SignupGroupFormContext';
 import { server } from '../tests/msw/server';
@@ -64,14 +65,16 @@ const customRender: CustomRender = (
     );
 
     return (
-      <RouterContext.Provider value={value}>
-        <SessionProvider session={session}>
-          {/* @ts-ignore */}
-          <QueryClientProvider client={queryClient}>
-            {children as React.ReactElement}
-          </QueryClientProvider>
-        </SessionProvider>
-      </RouterContext.Provider>
+      <NotificationsProvider>
+        <RouterContext.Provider value={value}>
+          <SessionProvider session={session}>
+            {/* @ts-ignore */}
+            <QueryClientProvider client={queryClient}>
+              {children as React.ReactElement}
+            </QueryClientProvider>
+          </SessionProvider>
+        </RouterContext.Provider>
+      </NotificationsProvider>
     );
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5361,13 +5361,6 @@ react-spring@9.3.0:
     "@react-spring/web" "~9.3.0"
     "@react-spring/zdog" "~9.3.0"
 
-react-toastify@^9.1.3:
-  version "9.1.3"
-  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-9.1.3.tgz#1e798d260d606f50e0fab5ee31daaae1d628c5ff"
-  integrity sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==
-  dependencies:
-    clsx "^1.1.1"
-
 react-use-measure@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.0.1.tgz#4f23f94c832cd4512da55acb300d1915dcbf3ae8"


### PR DESCRIPTION
## Description
- Add Notification component to common components. Use HDS Notification component as base and add id for it to be able to get it with document.getElementById
- Replace all Notifications with this component
- Implement `NotificationsProvider` component which is used to show multiple Notifications at the same time
- Add `useNotificationsContext` hook to get function to add new notifications to NotificationsContext
- Replace `toast.error` and `toast.success` messages with Notification messages added by `addNotification` function

## Closes
[LINK-1602](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1602)

## Screenshot
<img width="1504" alt="Screenshot 2023-10-13 at 10 10 27" src="https://github.com/City-of-Helsinki/linkedregistrations-ui/assets/24706814/4bbd65f2-5bf4-429f-b064-80b33fc813dc">



[LINK-1602]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ