### PR TITLE
LINK-1607 | Don't show signup form if signup is already closed

### DIFF
--- a/public/locales/en/signup.json
+++ b/public/locales/en/signup.json
@@ -87,6 +87,7 @@
   "placeholderStreetAddress": "Enter a street address",
   "placeholderZipcode": "Enter postcode",
   "signupDefaultTitle": "Participant {{index}}",
+  "signupIsEnded": "Registration for the event has ended",
   "timeLeft": "Time left to register",
   "titleAdditionalInfo": "Additional information",
   "titleBasicInfo": "Basic information of the registrant",

--- a/public/locales/fi/signup.json
+++ b/public/locales/fi/signup.json
@@ -87,6 +87,7 @@
   "placeholderStreetAddress": "Syötä katuosoite",
   "placeholderZipcode": "Syötä postinumero",
   "signupDefaultTitle": "Osallistuja {{index}}",
+  "signupIsEnded": "Ilmoittautuminen tapahtumaan on päättynyt",
   "timeLeft": "Aikaa jäljellä ilmoittautumisen tekoon",
   "titleAdditionalInfo": "Lisätiedot",
   "titleBasicInfo": "Ilmoittautujan perustiedot",

--- a/public/locales/sv/signup.json
+++ b/public/locales/sv/signup.json
@@ -87,6 +87,7 @@
   "placeholderStreetAddress": "Ange en gatuadress",
   "placeholderZipcode": "Ange postnummer",
   "signupDefaultTitle": "Deltagare {{index}}",
+  "signupIsEnded": "Anmälan till evenemanget är avslutad",
   "timeLeft": "Tid kvar att registrera sig",
   "titleAdditionalInfo": "Ytterligare information",
   "titleBasicInfo": "Grundläggande information om registranten",

--- a/src/common/components/errorTemplate/ErrorTemplate.tsx
+++ b/src/common/components/errorTemplate/ErrorTemplate.tsx
@@ -7,7 +7,7 @@ import styles from './errorTemplate.module.scss';
 
 interface Props {
   buttons?: React.ReactElement;
-  text: string;
+  text?: string;
   title: string;
 }
 
@@ -17,7 +17,7 @@ const ErrorTemplate: React.FC<Props> = ({ buttons, text, title }) => {
       <div className={styles.content}>
         <IconAlertCircle className={styles.icon} />
         <h1>{title}</h1>
-        <p>{text}</p>
+        {text && <p>{text}</p>}
         {buttons && <div className={styles.buttonsWrapper}>{buttons}</div>}
       </div>
     </Container>

--- a/src/domain/registration/__tests__/utils.test.ts
+++ b/src/domain/registration/__tests__/utils.test.ts
@@ -18,6 +18,7 @@ import {
   isAttendeeCapacityUsed,
   isRegistrationOpen,
   isRegistrationPossible,
+  isSignupEnded,
   isWaitingListCapacityUsed,
   registrationPathBuilder,
 } from '../utils';
@@ -319,6 +320,38 @@ describe('isRegistrationOpen', () => {
         })
       )
     ).toBe(false);
+  });
+});
+
+describe('isSignupEnded', () => {
+  beforeEach(() => {
+    advanceTo('2022-11-07');
+  });
+
+  it('should return false if enrolment_start_time is not defined', () => {
+    expect(isSignupEnded(fakeRegistration({ enrolment_end_time: '' }))).toBe(
+      false
+    );
+  });
+
+  it('should return false if enrolment_start_time is in the future', () => {
+    expect(
+      isSignupEnded(
+        fakeRegistration({
+          enrolment_end_time: new Date('2022-11-08').toISOString(),
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('should return true if enrolment_end_time is in the past', () => {
+    expect(
+      isSignupEnded(
+        fakeRegistration({
+          enrolment_end_time: new Date('2022-11-06').toISOString(),
+        })
+      )
+    ).toBe(true);
   });
 });
 

--- a/src/domain/registration/utils.ts
+++ b/src/domain/registration/utils.ts
@@ -117,7 +117,7 @@ export const getAttendeeCapacityError = (
   if (participantAmount < 1) {
     return t(`common:${VALIDATION_MESSAGE_KEYS.CAPACITY_MIN}`, {
       min: 1,
-    }) as string;
+    });
   }
 
   const freeCapacity = getFreeAttendeeOrWaitingListCapacity(registration);
@@ -125,7 +125,7 @@ export const getAttendeeCapacityError = (
   if (freeCapacity && participantAmount > freeCapacity) {
     return t(`common:${VALIDATION_MESSAGE_KEYS.CAPACITY_MAX}`, {
       max: freeCapacity,
-    }) as string;
+    });
   }
 
   return undefined;
@@ -145,6 +145,13 @@ export const isRegistrationOpen = (registration: Registration): boolean => {
   }
 
   return true;
+};
+
+export const isSignupEnded = (registration: Registration): boolean => {
+  const enrolmentEndTime = registration.enrolment_end_time;
+
+  // Signup is ended if enrolment end time is defined and in the past
+  return Boolean(enrolmentEndTime && isPast(new Date(enrolmentEndTime)));
 };
 
 export const isRegistrationPossible = (registration: Registration): boolean => {

--- a/src/domain/signupGroup/CreateSignupGroupPage.tsx
+++ b/src/domain/signupGroup/CreateSignupGroupPage.tsx
@@ -11,6 +11,7 @@ import { Event } from '../event/types';
 import NotFound from '../notFound/NotFound';
 import useEventAndRegistrationData from '../registration/hooks/useEventAndRegistrationData';
 import { Registration } from '../registration/types';
+import { isSignupEnded } from '../registration/utils';
 import SignupPageMeta from '../signup/signupPageMeta/SignupPageMeta';
 import { SignupServerErrorsProvider } from '../signup/signupServerErrorsContext/SignupServerErrorsContext';
 
@@ -19,6 +20,7 @@ import EventInfo from './eventInfo/EventInfo';
 import FormContainer from './formContainer/FormContainer';
 import SignupGroupForm from './signupGroupForm/SignupGroupForm';
 import { SignupGroupFormProvider } from './signupGroupFormContext/SignupGroupFormContext';
+import SignupIsEnded from './signupIsEnded/SignupIsEnded';
 import { getSignupGroupDefaultInitialValues } from './utils';
 
 type Props = {
@@ -62,11 +64,20 @@ const CreateSignupGroupPageWrapper: React.FC = () => {
   return (
     <LoadingSpinner isLoading={isLoading}>
       {registration && event ? (
-        <SignupGroupFormProvider registration={registration}>
-          <SignupServerErrorsProvider>
-            <CreateSignupGroupPage event={event} registration={registration} />
-          </SignupServerErrorsProvider>
-        </SignupGroupFormProvider>
+        <>
+          {isSignupEnded(registration) ? (
+            <SignupIsEnded event={event} />
+          ) : (
+            <SignupGroupFormProvider registration={registration}>
+              <SignupServerErrorsProvider>
+                <CreateSignupGroupPage
+                  event={event}
+                  registration={registration}
+                />
+              </SignupServerErrorsProvider>
+            </SignupGroupFormProvider>
+          )}
+        </>
       ) : (
         <NotFound />
       )}

--- a/src/domain/signupGroup/__tests__/CreateSignupGroupPage.test.tsx
+++ b/src/domain/signupGroup/__tests__/CreateSignupGroupPage.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-require-imports */
+import subDays from 'date-fns/subDays';
 import subYears from 'date-fns/subYears';
 import { axe } from 'jest-axe';
 import { rest } from 'msw';
@@ -163,6 +164,29 @@ test('should validate signup group form and focus invalid field', async () => {
       `/fi/registration/${registration.id}/signup-group/create/summary`
     )
   );
+});
+
+test('should show sign up is closed text if enrolment end date is in the past', async () => {
+  setQueryMocks(
+    rest.get(`*/registration/${TEST_REGISTRATION_ID}/`, (req, res, ctx) =>
+      res(
+        ctx.status(200),
+        ctx.json({
+          ...registration,
+          enrolment_end_time: subDays(new Date(), 2).toISOString(),
+        })
+      )
+    )
+  );
+
+  pushCreateSignupGroupRoute(TEST_REGISTRATION_ID);
+  renderComponent();
+
+  await loadingSpinnerIsNotInDocument();
+
+  await screen.findByRole('heading', {
+    name: /ilmoittautuminen tapahtumaan on päättynyt/i,
+  });
 });
 
 test('should show not found page if registration does not exist', async () => {

--- a/src/domain/signupGroup/signupIsEnded/SignupIsEnded.tsx
+++ b/src/domain/signupGroup/signupIsEnded/SignupIsEnded.tsx
@@ -1,0 +1,24 @@
+import { useTranslation } from 'next-i18next';
+import React from 'react';
+
+import ErrorTemplate from '../../../common/components/errorTemplate/ErrorTemplate';
+import MainContent from '../../app/layout/mainContent/MainContent';
+import { Event } from '../../event/types';
+import SignupPageMeta from '../../signup/signupPageMeta/SignupPageMeta';
+
+type Props = {
+  event: Event;
+};
+
+const SignupIsEnded: React.FC<Props> = ({ event }) => {
+  const { t } = useTranslation('signup');
+
+  return (
+    <MainContent>
+      <SignupPageMeta event={event} />
+      <ErrorTemplate title={t('signupIsEnded')} />
+    </MainContent>
+  );
+};
+
+export default SignupIsEnded;

--- a/src/domain/signupGroup/summaryPage/SummaryPage.tsx
+++ b/src/domain/signupGroup/summaryPage/SummaryPage.tsx
@@ -22,6 +22,7 @@ import { Event } from '../../event/types';
 import NotFound from '../../notFound/NotFound';
 import useEventAndRegistrationData from '../../registration/hooks/useEventAndRegistrationData';
 import { Registration } from '../../registration/types';
+import { isSignupEnded } from '../../registration/utils';
 import { clearSeatsReservationData } from '../../reserveSeats/utils';
 import { SIGNUP_QUERY_PARAMS } from '../../signup/constants';
 import { useSignupServerErrorsContext } from '../../signup/signupServerErrorsContext/hooks/useSignupServerErrorsContext';
@@ -34,6 +35,7 @@ import FormContainer from '../formContainer/FormContainer';
 import useSignupGroupActions from '../hooks/useSignupGroupActions';
 import ReservationTimer from '../reservationTimer/ReservationTimer';
 import { SignupGroupFormProvider } from '../signupGroupFormContext/SignupGroupFormContext';
+import SignupIsEnded from '../signupIsEnded/SignupIsEnded';
 import {
   clearCreateSignupGroupFormData,
   getSignupGroupDefaultInitialValues,
@@ -222,11 +224,17 @@ const SummaryPageWrapper: React.FC = () => {
   return (
     <LoadingSpinner isLoading={isLoading}>
       {event && registration ? (
-        <SignupGroupFormProvider registration={registration}>
-          <SignupServerErrorsProvider>
-            <SummaryPage event={event} registration={registration} />
-          </SignupServerErrorsProvider>
-        </SignupGroupFormProvider>
+        <>
+          {isSignupEnded(registration) ? (
+            <SignupIsEnded event={event} />
+          ) : (
+            <SignupGroupFormProvider registration={registration}>
+              <SignupServerErrorsProvider>
+                <SummaryPage event={event} registration={registration} />
+              </SignupServerErrorsProvider>
+            </SignupGroupFormProvider>
+          )}
+        </>
       ) : (
         <NotFound />
       )}

--- a/src/domain/signupGroup/summaryPage/__tests__/SummaryPage.test.tsx
+++ b/src/domain/signupGroup/summaryPage/__tests__/SummaryPage.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable max-len */
+import subDays from 'date-fns/subDays';
 import subYears from 'date-fns/subYears';
 import { rest } from 'msw';
 import singletonRouter from 'next/router';
@@ -209,6 +210,29 @@ test('should show server errors when post request fails', async () => {
   await user.click(submitButton);
 
   await screen.findByText(/lomakkeella on seuraavat virheet/i);
+});
+
+test('should show sign up is closed text if enrolment end date is in the past', async () => {
+  setQueryMocks(
+    rest.get(`*/registration/${TEST_REGISTRATION_ID}/`, (req, res, ctx) =>
+      res(
+        ctx.status(200),
+        ctx.json({
+          ...registration,
+          enrolment_end_time: subDays(new Date(), 2).toISOString(),
+        })
+      )
+    )
+  );
+
+  pushSummaryPageRoute(TEST_REGISTRATION_ID);
+  renderComponent();
+
+  await loadingSpinnerIsNotInDocument();
+
+  await screen.findByRole('heading', {
+    name: /ilmoittautuminen tapahtumaan on päättynyt/i,
+  });
 });
 
 test('should show not found page if registration does not exist', async () => {


### PR DESCRIPTION
## Description
Show "Ilmoittautuminen tapahtumaan on päättynyt" text instead of signup form is enrolment is already closed

## Closes
[LINK-1607](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1607)

## Screenshot
<img width="1250" alt="Screenshot 2023-10-24 at 13 02 58" src="https://github.com/City-of-Helsinki/linkedregistrations-ui/assets/24706814/e213636f-eb21-4830-93d4-358291a32b2e">


[LINK-1607]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ