### PR TITLE
LINK-1674 | Save user_consent via API

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -94,7 +94,7 @@
       "max": "The maximum number of participants is {{max}}.",
       "min": "The minimum number of participants is {{min}}."
     },
-    "signupAccepted": "Sharing information with the organizer must be approved",
+    "signupUserConsent": "Sharing information with the organizer must be approved",
     "string": {
       "charsLeft": "{{count}} character left",
       "charsLeft_other": "{{count}} characters left",

--- a/public/locales/en/signup.json
+++ b/public/locales/en/signup.json
@@ -45,7 +45,6 @@
     "tooltip": "Entrants have been added to the queue of registrants with a reserve place. Registration is confirmed only when a place in the queue becomes available. You will receive a notification by e-mail that the place has been confirmed."
   },
   "instructions": "Registration instructions",
-  "labelAccepted": "I agree to share my information with the organizer. We do not use the information you provide for marketing purposes. <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Data protection notice {{openInNewTab}}\">Data protection notice</a>",
   "labelAttendeeExtraInfo": "Additional information (optional)",
   "labelCity": "City",
   "labelDateOfBirth": "Date of birth",
@@ -61,6 +60,7 @@
   "labelSignupExtraInfo": "Additional information (optional)",
   "labelStreetAddress": "Street address",
   "labelZipcode": "Postcode",
+  "labelUserConsent": "I agree to share my information with the organizer. We do not use the information you provide for marketing purposes. <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Data protection notice {{openInNewTab}}\">Data protection notice</a>",
   "linkDataProtectionNotice": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/Kayttajatunnusten%20hallinta.pdf",
   "notifications": {
     "email": "By email",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -94,7 +94,7 @@
       "max": "Osallistujien enimmäismäärä on {{max}}.",
       "min": "Osallistujien vähimmäismäärä on {{min}}."
     },
-    "signupAccepted": "Tietojen jakaminen järjestäjän kanssa tulee olla hyväksytty",
+    "signupUserConsent": "Tietojen jakaminen järjestäjän kanssa tulee olla hyväksytty",
     "string": {
       "charsLeft": "{{count}} merkki jäljellä",
       "charsLeft_other": "{{count}} merkkiä jäljellä",

--- a/public/locales/fi/signup.json
+++ b/public/locales/fi/signup.json
@@ -45,7 +45,6 @@
     "text": "Jonopaikka",
     "tooltip": "Ilmoittautuja on lisätty ilmoittautujien jonoon. Ilmoittautuminen varmistuu vasta, kun paikka jonossa vapautuu. Saat paikan varmistumisesta ilmoituksen sähköpostitse."
   },
-  "labelAccepted": "Hyväksyn tietojeni jakamisen järjestäjän kanssa. Emme käytä antamiasi tietoja markkinointiin. <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Tietosuojaseloste {{openInNewTab}}\">Tietosuojaseloste</a>",
   "labelAttendeeExtraInfo": "Lisätietoa (valinnainen)",
   "labelCity": "Kaupunki",
   "labelDateOfBirth": "Syntymäaika",
@@ -61,6 +60,7 @@
   "labelSignupExtraInfo": "Lisätietoa (valinnainen)",
   "labelStreetAddress": "Katuosoite",
   "labelZipcode": "Postinumero",
+  "labelUserConsent": "Hyväksyn tietojeni jakamisen järjestäjän kanssa. Emme käytä antamiasi tietoja markkinointiin. <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Tietosuojaseloste {{openInNewTab}}\">Tietosuojaseloste</a>",
   "linkDataProtectionNotice": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/Kayttajatunnusten%20hallinta.pdf",
   "notifications": {
     "email": "Sähköpostilla",

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -94,7 +94,7 @@
       "max": "Max antal deltagare är {{max}}.",
       "min": "Minsta antal deltagare är {{min}}."
     },
-    "signupAccepted": "Dela information med arrangören måste godkännas",
+    "signupUserConsent": "Dela information med arrangören måste godkännas",
     "string": {
       "charsLeft": "{{count}} tecken kvar",
       "charsLeft_other": "{{count}} tecken kvar",

--- a/public/locales/sv/signup.json
+++ b/public/locales/sv/signup.json
@@ -45,7 +45,6 @@
     "text": "På väntelista",
     "tooltip": "Deltagare har lagts till i kön av anmälda med reservplats. Anmälan bekräftas först när en plats i kön blir ledig. Du får ett meddelande via e-post om att platsen är bekräftad."
   },
-  "labelAccepted": "Jag godkänner att dela min information med arrangören. Vi använder inte informationen du tillhandahåller för marknadsföringsändamål. <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Registerbeskrivningen {{openInNewTab}}\">Registerbeskrivningen</a>",
   "labelAttendeeExtraInfo": "Ytterligare information (valfritt)",
   "labelCity": "Staden",
   "labelDateOfBirth": "Födelsedatum",
@@ -61,6 +60,7 @@
   "labelSignupExtraInfo": "Ytterligare information (valfritt)",
   "labelStreetAddress": "Gatuadress",
   "labelZipcode": "Postnummer",
+  "labelUserConsent": "Jag godkänner att dela min information med arrangören. Vi använder inte informationen du tillhandahåller för marknadsföringsändamål. <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Registerbeskrivningen {{openInNewTab}}\">Registerbeskrivningen</a>",
   "linkDataProtectionNotice": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/Kayttajatunnusten%20hallinta.pdf",
   "notifications": {
     "email": "Via e-post",

--- a/src/__tests__/Pages.test.tsx
+++ b/src/__tests__/Pages.test.tsx
@@ -113,7 +113,6 @@ const isSignupGroupInDehydratedState = (dehydratedState: DehydratedState) => {
 };
 
 const signupGroupValues: SignupGroupFormFields = {
-  accepted: true,
   email: 'participant@email.com',
   extraInfo: '',
   membershipNumber: '',
@@ -135,6 +134,7 @@ const signupGroupValues: SignupGroupFormFields = {
       zipcode: '00100',
     },
   ],
+  userConsent: true,
 };
 
 const mocks = [

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,7 +16,7 @@ export enum VALIDATION_MESSAGE_KEYS {
   DATE = 'validation.string.date',
   EMAIL = 'validation.string.email',
   PHONE = 'validation.string.phone',
-  SIGNUP_ACCEPTED = 'validation.signupAccepted',
+  SIGNUP_USER_CONSENT = 'validation.signupUserConsent',
   STRING_REQUIRED = 'validation.string.required',
   ZIP = 'validation.string.zip',
 }

--- a/src/domain/signup/__mocks__/signup.ts
+++ b/src/domain/signup/__mocks__/signup.ts
@@ -8,6 +8,7 @@ const signup = fakeSignup({
   id: TEST_SIGNUP_ID,
   date_of_birth: formatDate(subYears(new Date(), 15), 'yyyy-MM-dd'),
   phone_number: '0441234567',
+  user_consent: true,
 });
 
 export { signup };

--- a/src/domain/signup/__tests__/utils.test.ts
+++ b/src/domain/signup/__tests__/utils.test.ts
@@ -111,6 +111,7 @@ describe('getSignupGroupInitialValuesFromSignup function', () => {
     const expectedPhoneNumber = '+358 44 123 4567';
     const expectedServiceLanguage = 'sv';
     const expectedStreetAddress = 'Test address';
+    const expectedUserConsent = true;
     const expectedZip = '12345';
 
     const {
@@ -122,6 +123,7 @@ describe('getSignupGroupInitialValuesFromSignup function', () => {
       phoneNumber,
       serviceLanguage,
       signups,
+      userConsent,
     } = getSignupGroupInitialValuesFromSignup(
       fakeSignup({
         city: expectedCity,
@@ -138,6 +140,7 @@ describe('getSignupGroupInitialValuesFromSignup function', () => {
         responsible_for_group: true,
         service_language: expectedServiceLanguage,
         street_address: expectedStreetAddress,
+        user_consent: expectedUserConsent,
         zipcode: expectedZip,
       })
     );
@@ -163,6 +166,7 @@ describe('getSignupGroupInitialValuesFromSignup function', () => {
     expect(notifications).toEqual(expectedNotifications);
     expect(phoneNumber).toBe(expectedPhoneNumber);
     expect(serviceLanguage).toBe(expectedServiceLanguage);
+    expect(userConsent).toBe(expectedUserConsent);
   });
 });
 
@@ -190,6 +194,7 @@ describe('getUpdateSignupPayload function', () => {
       responsible_for_group: false,
       service_language: null,
       street_address: null,
+      user_consent: false,
       zipcode: null,
     });
 
@@ -252,6 +257,7 @@ describe('getUpdateSignupPayload function', () => {
       responsible_for_group: true,
       service_language: serviceLanguage,
       street_address: streetAddress,
+      user_consent: false,
       zipcode,
     });
   });
@@ -274,6 +280,7 @@ describe('omitSensitiveDataFromSignupPayload', () => {
       responsible_for_group: true,
       service_language: 'fi',
       street_address: 'Address',
+      user_consent: true,
       zipcode: '123456',
     };
 
@@ -284,6 +291,7 @@ describe('omitSensitiveDataFromSignupPayload', () => {
       id: '1',
       notifications: NOTIFICATION_TYPE.EMAIL,
       responsible_for_group: true,
+      user_consent: true,
     });
     expect(filteredPayload.city).toBeUndefined();
     expect(filteredPayload.extra_info).toBeUndefined();

--- a/src/domain/signup/types.ts
+++ b/src/domain/signup/types.ts
@@ -22,6 +22,7 @@ export type SignupInput = {
   responsible_for_group: boolean;
   service_language?: stringOrNull;
   street_address?: stringOrNull;
+  user_consent: boolean;
   zipcode?: stringOrNull;
 };
 
@@ -47,6 +48,7 @@ export type Signup = {
   responsible_for_group: boolean;
   service_language?: stringOrNull;
   street_address?: stringOrNull;
+  user_consent?: boolean;
   zipcode?: stringOrNull;
 };
 

--- a/src/domain/signup/utils.ts
+++ b/src/domain/signup/utils.ts
@@ -123,7 +123,6 @@ export const getSignupGroupInitialValuesFromSignup = (
   signup: Signup
 ): SignupGroupFormFields => {
   return {
-    accepted: true,
     email: signup.email ?? '',
     extraInfo: '',
     membershipNumber: signup.membership_number ?? '',
@@ -132,6 +131,7 @@ export const getSignupGroupInitialValuesFromSignup = (
     phoneNumber: signup.phone_number ?? '',
     serviceLanguage: signup.service_language ?? '',
     signups: [getSignupInitialValues(signup)],
+    userConsent: !!signup.user_consent,
   };
 };
 
@@ -150,6 +150,7 @@ export const getSignupPayload = ({
     nativeLanguage,
     phoneNumber,
     serviceLanguage,
+    userConsent,
   } = formValues;
 
   const {
@@ -180,6 +181,7 @@ export const getSignupPayload = ({
     service_language: serviceLanguage || null,
     street_address: streetAddress || null,
     zipcode: zipcode || null,
+    user_consent: userConsent,
   };
 };
 

--- a/src/domain/signupGroup/__tests__/utils.test.ts
+++ b/src/domain/signupGroup/__tests__/utils.test.ts
@@ -66,6 +66,7 @@ describe('getSignupGroupPayload function', () => {
           service_language: null,
           street_address: null,
           zipcode: null,
+          user_consent: false,
         },
       ],
     });
@@ -83,6 +84,7 @@ describe('getSignupGroupPayload function', () => {
       phoneNumber = '0441234567',
       serviceLanguage = 'sv',
       streetAddress = 'Street address',
+      userConsent = true,
       zipcode = '00100';
     const payload = getSignupGroupPayload({
       formValues: {
@@ -93,7 +95,7 @@ describe('getSignupGroupPayload function', () => {
             dateOfBirth,
             extraInfo,
             firstName,
-            id: null,
+            id: TEST_SIGNUP_ID,
             inWaitingList: false,
             lastName,
             responsibleForGroup: false,
@@ -108,6 +110,7 @@ describe('getSignupGroupPayload function', () => {
         notifications,
         phoneNumber,
         serviceLanguage,
+        userConsent,
       },
       registration,
       reservationCode,
@@ -124,6 +127,7 @@ describe('getSignupGroupPayload function', () => {
           email,
           extra_info: extraInfo,
           first_name: firstName,
+          id: TEST_SIGNUP_ID,
           last_name: lastName,
           membership_number: membershipNumber,
           native_language: nativeLanguage,
@@ -132,6 +136,7 @@ describe('getSignupGroupPayload function', () => {
           responsible_for_group: true,
           service_language: serviceLanguage,
           street_address: streetAddress,
+          user_consent: userConsent,
           zipcode,
         },
       ],
@@ -194,7 +199,6 @@ describe('getSignupDefaultInitialValues function', () => {
 describe('getSignupGroupDefaultInitialValues function', () => {
   it('should return signup group default initial values', () => {
     expect(getSignupGroupDefaultInitialValues()).toEqual({
-      accepted: false,
       email: '',
       extraInfo: '',
       membershipNumber: '',
@@ -216,6 +220,7 @@ describe('getSignupGroupDefaultInitialValues function', () => {
           zipcode: '',
         },
       ],
+      userConsent: false,
     });
   });
 });
@@ -373,6 +378,28 @@ describe('getSignupGroupInitialValues function', () => {
     expect(initialValues.signups[2].id).toEqual(signup1.id);
     expect(initialValues.signups[3].id).toEqual(signup4.id);
   });
+
+  it('should set userConsent false if any signups has user_consent false', () => {
+    const signup1 = fakeSignup({ user_consent: false });
+    const signup2 = fakeSignup({ user_consent: true });
+    const signupGroup = fakeSignupGroup({
+      signups: [signup1, signup2],
+    });
+
+    const { userConsent } = getSignupGroupInitialValues(signupGroup);
+    expect(userConsent).toBeFalsy();
+  });
+
+  it('should set userConsent true if all signups has user_consent true', () => {
+    const signup1 = fakeSignup({ user_consent: true });
+    const signup2 = fakeSignup({ user_consent: true });
+    const signupGroup = fakeSignupGroup({
+      signups: [signup1, signup2],
+    });
+
+    const { userConsent } = getSignupGroupInitialValues(signupGroup);
+    expect(userConsent).toBeTruthy();
+  });
 });
 
 describe('isSignupFieldRequired', () => {
@@ -453,7 +480,6 @@ describe('getUpdateSignupGroupPayload function', () => {
           email: null,
           extra_info: '',
           first_name: '',
-          id: undefined,
           last_name: '',
           membership_number: '',
           native_language: null,
@@ -463,6 +489,7 @@ describe('getUpdateSignupGroupPayload function', () => {
           service_language: null,
           street_address: null,
           zipcode: null,
+          user_consent: false,
         },
       ],
     });
@@ -482,6 +509,7 @@ describe('getUpdateSignupGroupPayload function', () => {
       phoneNumber = '0441234567',
       serviceLanguage = 'sv',
       streetAddress = 'Street address',
+      userConsent = true,
       zipcode = '00100';
     const signups = [
       {
@@ -509,6 +537,7 @@ describe('getUpdateSignupGroupPayload function', () => {
         phoneNumber,
         serviceLanguage,
         signups,
+        userConsent,
       },
       id: TEST_SIGNUP_GROUP_ID,
       registration,
@@ -535,6 +564,7 @@ describe('getUpdateSignupGroupPayload function', () => {
           service_language: serviceLanguage,
           street_address: streetAddress,
           zipcode,
+          user_consent: userConsent,
         },
       ],
     });
@@ -564,6 +594,7 @@ describe('omitSensitiveDataFromSignupGroupPayload', () => {
           service_language: 'fi',
           street_address: 'Address',
           zipcode: '123456',
+          user_consent: true,
         },
       ],
     };
@@ -579,6 +610,7 @@ describe('omitSensitiveDataFromSignupGroupPayload', () => {
           id: '1',
           notifications: NOTIFICATION_TYPE.EMAIL,
           responsible_for_group: true,
+          user_consent: true,
         },
       ],
     });

--- a/src/domain/signupGroup/__tests__/validation.test.ts
+++ b/src/domain/signupGroup/__tests__/validation.test.ts
@@ -266,7 +266,6 @@ describe('signupSchema function', () => {
 describe('testSignupGroupSchema function', () => {
   const registration = fakeRegistration();
   const validSignupGroup: SignupGroupFormFields = {
-    accepted: true,
     email: 'user@email.com',
     extraInfo: '',
     membershipNumber: '',
@@ -275,6 +274,7 @@ describe('testSignupGroupSchema function', () => {
     phoneNumber: '',
     serviceLanguage: 'fi',
     signups: [],
+    userConsent: true,
   };
 
   test('should return true if signup group data is valid', async () => {

--- a/src/domain/signupGroup/constants.ts
+++ b/src/domain/signupGroup/constants.ts
@@ -14,7 +14,6 @@ export enum SIGNUP_FIELDS {
 }
 
 export enum SIGNUP_GROUP_FIELDS {
-  ACCEPTED = 'accepted',
   EMAIL = 'email',
   EXTRA_INFO = 'extraInfo',
   MEMBERSHIP_NUMBER = 'membershipNumber',
@@ -23,6 +22,7 @@ export enum SIGNUP_GROUP_FIELDS {
   PHONE_NUMBER = 'phoneNumber',
   SERVICE_LANGUAGE = 'serviceLanguage',
   SIGNUPS = 'signups',
+  USER_CONSENT = 'userConsent',
 }
 
 export enum NOTIFICATIONS {
@@ -44,7 +44,6 @@ export const SIGNUP_INITIAL_VALUES: SignupFormFields = {
 };
 
 export const SIGNUP_GROUP_INITIAL_VALUES: SignupGroupFormFields = {
-  [SIGNUP_GROUP_FIELDS.ACCEPTED]: false,
   [SIGNUP_GROUP_FIELDS.EMAIL]: '',
   [SIGNUP_GROUP_FIELDS.EXTRA_INFO]: '',
   [SIGNUP_GROUP_FIELDS.MEMBERSHIP_NUMBER]: '',
@@ -53,6 +52,7 @@ export const SIGNUP_GROUP_INITIAL_VALUES: SignupGroupFormFields = {
   [SIGNUP_GROUP_FIELDS.PHONE_NUMBER]: '',
   [SIGNUP_GROUP_FIELDS.SERVICE_LANGUAGE]: '',
   [SIGNUP_GROUP_FIELDS.SIGNUPS]: [],
+  [SIGNUP_GROUP_FIELDS.USER_CONSENT]: false,
 };
 
 export const SIGNUP_GROUP_FORM_SELECT_FIELDS = [

--- a/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
+++ b/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
@@ -430,7 +430,7 @@ const SignupGroupForm: React.FC<Props> = ({
                     )}
                   </Fieldset>
 
-                  {!isEditingMode && (
+                  {!initialValues.userConsent && (
                     <>
                       <FormGroup>
                         <Field
@@ -438,14 +438,14 @@ const SignupGroupForm: React.FC<Props> = ({
                           label={
                             <span
                               dangerouslySetInnerHTML={{
-                                __html: t('labelAccepted', {
+                                __html: t('labelUserConsent', {
                                   openInNewTab: t('common:openInNewTab'),
                                   url: t('linkDataProtectionNotice'),
                                 }),
                               }}
                             />
                           }
-                          name={SIGNUP_GROUP_FIELDS.ACCEPTED}
+                          name={SIGNUP_GROUP_FIELDS.USER_CONSENT}
                           component={CheckboxField}
                         />
                       </FormGroup>

--- a/src/domain/signupGroup/summaryPage/__tests__/SummaryPage.test.tsx
+++ b/src/domain/signupGroup/summaryPage/__tests__/SummaryPage.test.tsx
@@ -54,7 +54,6 @@ const signupGroup = fakeSignupGroup({
 });
 
 const signupGroupValues: SignupGroupFormFields = {
-  accepted: true,
   email: 'participant@email.com',
   extraInfo: '',
   membershipNumber: '',
@@ -76,6 +75,7 @@ const signupGroupValues: SignupGroupFormFields = {
       zipcode: '00100',
     },
   ],
+  userConsent: true,
 };
 
 const defaultMocks = [

--- a/src/domain/signupGroup/types.ts
+++ b/src/domain/signupGroup/types.ts
@@ -47,7 +47,6 @@ export type SignupFormFields = {
 };
 
 export type SignupGroupFormFields = {
-  [SIGNUP_GROUP_FIELDS.ACCEPTED]: boolean;
   [SIGNUP_GROUP_FIELDS.EMAIL]: string;
   [SIGNUP_GROUP_FIELDS.EXTRA_INFO]: string;
   [SIGNUP_GROUP_FIELDS.MEMBERSHIP_NUMBER]: string;
@@ -56,6 +55,7 @@ export type SignupGroupFormFields = {
   [SIGNUP_GROUP_FIELDS.PHONE_NUMBER]: string;
   [SIGNUP_GROUP_FIELDS.SERVICE_LANGUAGE]: string;
   [SIGNUP_GROUP_FIELDS.SIGNUPS]: SignupFormFields[];
+  [SIGNUP_GROUP_FIELDS.USER_CONSENT]: boolean;
 };
 
 export type SignupFields = {

--- a/src/domain/signupGroup/utils.ts
+++ b/src/domain/signupGroup/utils.ts
@@ -152,7 +152,6 @@ export const getSignupGroupInitialValues = (
   const responsibleSignup = signups[0];
 
   return {
-    accepted: true,
     email: responsibleSignup?.email ?? '',
     extraInfo: signupGroup.extra_info ?? '',
     membershipNumber: responsibleSignup?.membership_number ?? '',
@@ -161,6 +160,7 @@ export const getSignupGroupInitialValues = (
     phoneNumber: responsibleSignup?.phone_number ?? '',
     serviceLanguage: responsibleSignup?.service_language ?? '',
     signups: signups.map((su) => getSignupInitialValues(su)),
+    userConsent: signups.every((su) => su.user_consent),
   };
 };
 

--- a/src/domain/signupGroup/validation.ts
+++ b/src/domain/signupGroup/validation.ts
@@ -146,9 +146,9 @@ export const getSignupGroupSchema = (registration: Registration) => {
     [SIGNUP_GROUP_FIELDS.EXTRA_INFO]: getStringSchema(
       isSignupFieldRequired(registration, SIGNUP_GROUP_FIELDS.EXTRA_INFO)
     ),
-    [SIGNUP_GROUP_FIELDS.ACCEPTED]: Yup.bool().oneOf(
+    [SIGNUP_GROUP_FIELDS.USER_CONSENT]: Yup.bool().oneOf(
       [true],
-      VALIDATION_MESSAGE_KEYS.SIGNUP_ACCEPTED
+      VALIDATION_MESSAGE_KEYS.SIGNUP_USER_CONSENT
     ),
   });
 };

--- a/src/utils/mockDataUtils.ts
+++ b/src/utils/mockDataUtils.ts
@@ -332,6 +332,7 @@ export const fakeSignup = (overrides?: Partial<Signup>): Signup => {
       responsible_for_group: false,
       service_language: 'fi',
       street_address: faker.location.streetAddress(),
+      user_consent: false,
       zipcode: faker.location.zipCode('#####'),
     },
     overrides


### PR DESCRIPTION
## Description
Save user consent via API when creating a new signup group
Show user consent checkbox also if editing a signup group and any of user_consent is false

## Closes
[LINK-1674](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1674)

[LINK-1674]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ