### PR TITLE
LINK-1719 | Use signup endpoint when creating a signup

### DIFF
--- a/src/__tests__/Pages.test.tsx
+++ b/src/__tests__/Pages.test.tsx
@@ -30,6 +30,9 @@ import { mockedUserResponse } from '../domain/user/__mocks__/user';
 import AttendanceListPage, {
   getServerSideProps as getAttendanceListPageServerSideProps,
 } from '../pages/registration/[registrationId]/attendance-list/index';
+import SignupCompletedPage, {
+  getServerSideProps as getSignupCompletedPageServerSideProps,
+} from '../pages/registration/[registrationId]/signup/[signupId]/completed';
 import EditSignupPage, {
   getServerSideProps as getEditSignupPageServerSideProps,
 } from '../pages/registration/[registrationId]/signup/[signupId]/edit/index';
@@ -332,6 +335,31 @@ describe('SummaryPage', () => {
   });
 });
 
+describe('SignupCompletedPage', () => {
+  it('should render heading', async () => {
+    singletonRouter.push({
+      pathname: ROUTES.SIGNUP_COMPLETED,
+      query: { signupId: signup.id, registrationId: registration.id },
+    });
+
+    render(<SignupCompletedPage />);
+
+    await isHeadingRendered('Kiitos ilmoittautumisestasi!');
+  });
+
+  it('should prefetch data', async () => {
+    const { props } = (await getSignupCompletedPageServerSideProps({
+      locale: 'fi',
+      query: { registrationId: registration.id, signupId: signup.id },
+    } as unknown as GetServerSidePropsContext)) as {
+      props: ExtendedSSRConfig;
+    };
+
+    isRegistrationInDehydratedState(props.dehydratedState);
+    isSignupInDehydratedState(props.dehydratedState);
+  });
+});
+
 describe('SignupGroupCompletedPage', () => {
   it('should render heading', async () => {
     singletonRouter.push({
@@ -347,12 +375,13 @@ describe('SignupGroupCompletedPage', () => {
   it('should prefetch data', async () => {
     const { props } = (await getSignupGroupCompletedPageServerSideProps({
       locale: 'fi',
-      query: { registrationId: registration.id },
+      query: { registrationId: registration.id, signupGroupId: signupGroup.id },
     } as unknown as GetServerSidePropsContext)) as {
       props: ExtendedSSRConfig;
     };
 
     isRegistrationInDehydratedState(props.dehydratedState);
+    isSignupGroupInDehydratedState(props.dehydratedState);
   });
 });
 

--- a/src/domain/app/routes/constants.ts
+++ b/src/domain/app/routes/constants.ts
@@ -7,6 +7,7 @@ export enum ROUTES {
   EDIT_SIGNUP_GROUP = '/registration/[registrationId]/signup-group/[signupGroupId]/edit',
   HOME = '/',
   SIGNUP_CANCELLED = '/registration/[registrationId]/signup/cancelled',
+  SIGNUP_COMPLETED = '/registration/[registrationId]/signup/[signupId]/completed',
   SIGNUP_GROUP_CANCELLED = '/registration/[registrationId]/signup-group/cancelled',
   SIGNUP_GROUP_COMPLETED = '/registration/[registrationId]/signup-group/[signupGroupId]/completed',
   SIGNUPS = '/registration/[registrationId]/signup',

--- a/src/domain/signup/SignupCompletedPage.tsx
+++ b/src/domain/signup/SignupCompletedPage.tsx
@@ -1,0 +1,28 @@
+import LoadingSpinner from '../../common/components/loadingSpinner/LoadingSpinner';
+import NotFound from '../notFound/NotFound';
+import useEventAndRegistrationData from '../registration/hooks/useEventAndRegistrationData';
+import { SignupCompletedPage } from '../signupGroup/SignupGroupCompletedPage';
+
+import { ATTENDEE_STATUS } from './constants';
+import useSignupData from './hooks/useSignupData';
+
+const SignupCompletedPageWrapper: React.FC = () => {
+  const { event, isLoading, registration } = useEventAndRegistrationData();
+  const { isLoading: isLoadingSignup, signup } = useSignupData();
+
+  return (
+    <LoadingSpinner isLoading={isLoading || isLoadingSignup}>
+      {event && registration && signup ? (
+        <SignupCompletedPage
+          event={event}
+          inWaitingList={signup.attendee_status === ATTENDEE_STATUS.Waitlisted}
+          registration={registration}
+        />
+      ) : (
+        <NotFound />
+      )}
+    </LoadingSpinner>
+  );
+};
+
+export default SignupCompletedPageWrapper;

--- a/src/domain/signup/constants.ts
+++ b/src/domain/signup/constants.ts
@@ -19,6 +19,7 @@ export const TEST_CONTACT_PERSON_ID = 'contact:0';
 export const TEST_SIGNUP_ID = 'signup:1';
 
 export enum SIGNUP_ACTIONS {
+  CREATE = 'create',
   DELETE = 'delete',
   UPDATE = 'update',
 }

--- a/src/domain/signup/mutation.ts
+++ b/src/domain/signup/mutation.ts
@@ -7,13 +7,37 @@ import {
 import { ExtendedSession } from '../../types';
 
 import {
+  CreateSignupsMutationInput,
+  CreateSignupsResponse,
   DeleteSignupMutationInput,
   PatchSignupMutationInput,
   Signup,
   UpdateSignupMutationInput,
 } from './types';
-import { deleteSignup, patchSignup, updateSignup } from './utils';
+import {
+  createSignups,
+  deleteSignup,
+  patchSignup,
+  updateSignup,
+} from './utils';
 
+export const useCreateSignupsMutation = ({
+  options,
+  session,
+}: {
+  options?: UseMutationOptions<
+    CreateSignupsResponse,
+    Error,
+    CreateSignupsMutationInput
+  >;
+  session: ExtendedSession | null;
+}): UseMutationResult<
+  CreateSignupsResponse,
+  Error,
+  CreateSignupsMutationInput
+> => {
+  return useMutation((input) => createSignups({ input, session }), options);
+};
 export const useDeleteSignupMutation = ({
   options,
   session,

--- a/src/domain/signup/signupServerErrorsContext/utils.ts
+++ b/src/domain/signup/signupServerErrorsContext/utils.ts
@@ -20,7 +20,7 @@ const isContactPersonObjectError = ({
   // API returns '{contact_person: ["Tämän kentän arvo ei voi olla "null"."]}' error when
   // trying to set null value for contact_person. Use parseContactPersonServerError only
   // when error type is object
-  !(Array.isArray(error) && typeof error[0] == 'string');
+  !(Array.isArray(error) && typeof error[0] === 'string');
 
 export const parseSignupGroupServerErrors = ({
   error,

--- a/src/domain/signup/types.ts
+++ b/src/domain/signup/types.ts
@@ -71,6 +71,14 @@ export type SignupsResponse = {
   meta: Meta;
 };
 
+export type CreateSignupsResponse = Signup[];
+
+export type CreateSignupsMutationInput = {
+  registration: string;
+  reservation_code: string;
+  signups: SignupInput[];
+};
+
 export type DeleteSignupMutationInput = {
   registrationId: string;
   signupId: string;

--- a/src/domain/signupGroup/SignupGroupCompletedPage.tsx
+++ b/src/domain/signupGroup/SignupGroupCompletedPage.tsx
@@ -17,19 +17,18 @@ import { SIGNUP_QUERY_PARAMS } from '../signup/constants';
 
 import ConfirmationMessage from './confirmationMessage/ConfirmationMessage';
 import useSignupGroupData from './hooks/useSignupGroupData';
-import { SignupGroup } from './types';
 import { isAnySignupInWaitingList } from './utils';
 
 type Props = {
   event: Event;
+  inWaitingList: boolean;
   registration: Registration;
-  signupGroup: SignupGroup;
 };
 
-const SignupGroupCompletedPage: React.FC<Props> = ({
+export const SignupCompletedPage: React.FC<Props> = ({
   event,
+  inWaitingList,
   registration,
-  signupGroup,
 }) => {
   const { query } = useRouter();
   const { [SIGNUP_QUERY_PARAMS.REDIRECT_URL]: redirectUrl } = query;
@@ -38,7 +37,6 @@ const SignupGroupCompletedPage: React.FC<Props> = ({
 
   const { name } = getEventFields(event, locale);
   const { confirmationMessage } = getRegistrationFields(registration, locale);
-  const inWaitingList = isAnySignupInWaitingList(signupGroup);
 
   React.useEffect(() => {
     if (typeof redirectUrl === 'string') {
@@ -88,10 +86,10 @@ const SignupGroupCompletedPageWrapper: React.FC = () => {
   return (
     <LoadingSpinner isLoading={isLoading || isLoadingSignupGroup}>
       {event && registration && signupGroup ? (
-        <SignupGroupCompletedPage
+        <SignupCompletedPage
           event={event}
+          inWaitingList={isAnySignupInWaitingList(signupGroup)}
           registration={registration}
-          signupGroup={signupGroup}
         />
       ) : (
         <NotFound />

--- a/src/domain/signupGroup/__tests__/EditSignupGroupPage.test.tsx
+++ b/src/domain/signupGroup/__tests__/EditSignupGroupPage.test.tsx
@@ -190,6 +190,23 @@ test('should route to page defined in returnPath when clicking back button', asy
   );
 });
 
+test('all fields should be read-only if signup is not created by user', async () => {
+  setQueryMocks(
+    ...mockedLanguagesResponses,
+    mockedUserResponse,
+    mockedRegistrationResponse,
+    mockedSignupGroupNotCreatedByUserResponse
+  );
+  pushEditSignupGroupRoute(TEST_REGISTRATION_ID);
+  renderComponent();
+
+  await shouldRenderSignupFormReadOnlyFields();
+
+  expect(
+    screen.queryByRole('button', { name: /tallenna/i })
+  ).not.toBeInTheDocument();
+});
+
 test('should route to the first page defined in returnPath when clicking back button', async () => {
   const user = userEvent.setup();
   setQueryMocks(...defaultMocks);
@@ -207,23 +224,6 @@ test('should route to the first page defined in returnPath when clicking back bu
   expect(mockRouter.asPath).toBe(
     `/registration/${TEST_REGISTRATION_ID}/signup`
   );
-});
-
-test('all fields should be read-only if signup is not created by user', async () => {
-  setQueryMocks(
-    ...mockedLanguagesResponses,
-    mockedUserResponse,
-    mockedRegistrationResponse,
-    mockedSignupGroupNotCreatedByUserResponse
-  );
-  pushEditSignupGroupRoute(TEST_REGISTRATION_ID);
-  renderComponent();
-
-  await shouldRenderSignupFormReadOnlyFields();
-
-  expect(
-    screen.queryByRole('button', { name: /tallenna/i })
-  ).not.toBeInTheDocument();
 });
 
 test('should show error message when updating signup group fails', async () => {

--- a/src/domain/signupGroup/editButtonPanel/EditButtonPanel.tsx
+++ b/src/domain/signupGroup/editButtonPanel/EditButtonPanel.tsx
@@ -33,7 +33,9 @@ const EditButtonPanel: React.FC<EditButtonPanelProps> = ({
     if (!returnPathQuery) return;
 
     const returnPath =
-      typeof returnPathQuery == 'string' ? returnPathQuery : returnPathQuery[0];
+      typeof returnPathQuery === 'string'
+        ? returnPathQuery
+        : returnPathQuery[0];
 
     router.push(returnPath);
   };

--- a/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
+++ b/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
@@ -521,7 +521,8 @@ const SignupGroupForm: React.FC<Props> = ({
                       </div>
                     </FormGroup>
                     {/* Don't show group extra info field when editing a single signup */}
-                    {!signup && (
+                    {(!signup ||
+                      (!isEditingMode && values.signups.length > 1)) && (
                       <FormGroup>
                         <Field
                           name={SIGNUP_GROUP_FIELDS.EXTRA_INFO}

--- a/src/domain/signupGroup/utils.ts
+++ b/src/domain/signupGroup/utils.ts
@@ -248,7 +248,7 @@ export const isSignupFieldRequired = (
 export const isAnySignupInWaitingList = (signupGroup: SignupGroup): boolean =>
   Boolean(
     signupGroup.signups.find(
-      (su) => su.attendee_status == ATTENDEE_STATUS.Waitlisted
+      (su) => su.attendee_status === ATTENDEE_STATUS.Waitlisted
     )
   );
 

--- a/src/domain/singups/signupsTable/__tests__/SignupsTable.test.tsx
+++ b/src/domain/singups/signupsTable/__tests__/SignupsTable.test.tsx
@@ -28,6 +28,7 @@ import {
 import SignupsTable, { SignupsTableProps } from '../SignupsTable';
 
 configure({ defaultHidden: true });
+
 jest.mock('next/dist/client/router', () => require('next-router-mock'));
 
 const signupName = [signupNames[0].first_name, signupNames[0].last_name].join(

--- a/src/pages/registration/[registrationId]/signup/[signupId]/completed/index.tsx
+++ b/src/pages/registration/[registrationId]/signup/[signupId]/completed/index.tsx
@@ -1,0 +1,15 @@
+import { NextPage } from 'next';
+
+import SignupCompletedPage from '../../../../../../domain/signup/SignupCompletedPage';
+import generateGetServerSideProps from '../../../../../../utils/generateGetServerSideProps';
+
+const SignupCompleted: NextPage = () => <SignupCompletedPage />;
+
+export const getServerSideProps = generateGetServerSideProps({
+  shouldPrefetchPlace: false,
+  shouldPrefetchSignup: true,
+  shouldPrefetchSignupGroup: false,
+  translationNamespaces: ['common', 'signup'],
+});
+
+export default SignupCompleted;


### PR DESCRIPTION
## Description
- Use signup bulk create endpoint to create a signup without group when only 1 signup is added to create signup form
- Redirect user to signup completed page after creating a signup

## Closes
[LINK-1719](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1719)

[LINK-1719]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ