### PR TITLE
LINK-1738 | Logout from Tunnistamo after signout

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -2,6 +2,6 @@
 module.exports = {
   i18n: {
     defaultLocale: 'default',
-    locales: ['default', 'en', 'fi', 'sv'],
+    locales: ['default', 'fi', 'en', 'sv'],
   },
 };

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -48,6 +48,10 @@
   "loading": "Loading...",
   "loadingFinished": "Loading finished",
   "logo": "City of Helsinki - logo",
+  "logout": {
+    "text": "You have been logged out of the service.",
+    "title": "Logout"
+  },
   "navigation": {
     "ariaLanguageSelection": "Choose language",
     "backToSignupGroupForm": "Back to the registration form",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -48,6 +48,10 @@
   "loading": "Ladataan...",
   "loadingFinished": "Lataaminen päättynyt",
   "logo": "Helsingin kaupunki - logo",
+  "logout": {
+    "text": "Olet kirjautunut ulos palvelusta.",
+    "title": "Uloskirjautuminen"
+  },
   "navigation": {
     "ariaLanguageSelection": "Kielen valinta",
     "backToSignupGroupForm": "Palaa ilmoittautumiskaavakkeeseen",

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -48,6 +48,10 @@
   "loading": "Laddar...",
   "loadingFinished": "Laddningen är klar",
   "logo": "Helsingfors stad - logo",
+  "logout": {
+    "text": "Du har loggat ut från tjänsten.",
+    "title": "Logga ut"
+  },
   "navigation": {
     "ariaLanguageSelection": "Välja spräk",
     "backToSignupGroupForm": "Återgå till registreringsformuläret",

--- a/src/__tests__/Pages.test.tsx
+++ b/src/__tests__/Pages.test.tsx
@@ -27,6 +27,9 @@ import {
 } from '../domain/signupGroup/constants';
 import { SignupGroupFormFields } from '../domain/signupGroup/types';
 import { mockedUserResponse } from '../domain/user/__mocks__/user';
+import LogoutPage, {
+  getServerSideProps as getLogoutPageServerSideProps,
+} from '../pages/logout';
 import AttendanceListPage, {
   getServerSideProps as getAttendanceListPageServerSideProps,
 } from '../pages/registration/[registrationId]/attendance-list/index';
@@ -437,5 +440,26 @@ describe('SignupCancelledPage', () => {
     };
 
     isRegistrationInDehydratedState(props.dehydratedState);
+  });
+});
+
+describe('LogoutPage', () => {
+  it('should render heading', async () => {
+    singletonRouter.push({ pathname: ROUTES.LOGOUT });
+
+    render(<LogoutPage />);
+
+    await isHeadingRendered('Uloskirjautuminen');
+  });
+
+  it('should get correct translations namespaces', async () => {
+    const { props } = (await getLogoutPageServerSideProps({
+      locale: 'fi',
+      query: { registrationId: registration.id },
+    } as unknown as GetServerSidePropsContext)) as {
+      props: ExtendedSSRConfig;
+    };
+
+    expect(props._nextI18Next?.ns).toEqual(['common']);
   });
 });

--- a/src/common/components/errorPageWithLogoutButton/ErrorPageWithLogoutButton.tsx
+++ b/src/common/components/errorPageWithLogoutButton/ErrorPageWithLogoutButton.tsx
@@ -1,0 +1,48 @@
+import { useTranslation } from 'next-i18next';
+import React from 'react';
+
+import MainContent from '../../../domain/app/layout/mainContent/MainContent';
+import useSignOut from '../../../hooks/useSignOut';
+import Button from '../button/Button';
+import ErrorTemplate from '../errorTemplate/ErrorTemplate';
+import ErrorPageMeta from '../errrorPageMeta/ErrorPageMeta';
+import PageWrapper from '../pageWrapper/PageWrapper';
+
+import styles from './errorPageWithLogoutButton.module.scss';
+
+type Props = {
+  text: string;
+  title: string;
+};
+
+const ErrorPageWithLogoutButton: React.FC<Props> = ({ text, title }) => {
+  const { t } = useTranslation('common');
+
+  const { handleSignOut } = useSignOut();
+  return (
+    <PageWrapper>
+      <ErrorPageMeta description={text} title={title} />
+
+      <MainContent>
+        <ErrorTemplate
+          buttons={
+            <div className={styles.buttons}>
+              <Button
+                fullWidth={true}
+                onClick={handleSignOut}
+                type="button"
+                variant="primary"
+              >
+                {t('signOut')}
+              </Button>
+            </div>
+          }
+          text={text}
+          title={title}
+        />
+      </MainContent>
+    </PageWrapper>
+  );
+};
+
+export default ErrorPageWithLogoutButton;

--- a/src/common/components/errorPageWithLogoutButton/errorPageWithLogoutButton.module.scss
+++ b/src/common/components/errorPageWithLogoutButton/errorPageWithLogoutButton.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/widths.scss';
+@import '../../../styles/widths.scss';
 
 .buttons {
   button {

--- a/src/common/components/errorPageWithLogoutButton/testUtils.ts
+++ b/src/common/components/errorPageWithLogoutButton/testUtils.ts
@@ -1,0 +1,31 @@
+import * as nextAuth from 'next-auth/react';
+
+import { screen, userEvent } from '../../../utils/testUtils';
+
+const getSignOutButton = () => {
+  return screen.getByRole('button', { name: /kirjaudu ulos/i });
+};
+
+export const shouldRenderErrorPageTexts = async ({
+  text,
+  title,
+}: {
+  text: string;
+  title: string;
+}) => {
+  expect(screen.getByRole('heading', { name: title })).toBeInTheDocument();
+  expect(screen.getByText(text)).toBeInTheDocument();
+};
+
+export const shouldSignOut = async () => {
+  const user = userEvent.setup();
+  jest
+    .spyOn(nextAuth, 'signOut')
+    .mockImplementation()
+    .mockResolvedValue({ url: 'https://test.com' });
+
+  const signoutButton = getSignOutButton();
+  await user.click(signoutButton);
+
+  expect(nextAuth.signOut).toBeCalled();
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,3 +35,5 @@ export enum FORM_NAMES {
 }
 
 export const READ_ONLY_PLACEHOLDER = '-';
+
+export const SIGNOUT_REDIRECT = '/signout';

--- a/src/domain/app/header/Header.tsx
+++ b/src/domain/app/header/Header.tsx
@@ -8,13 +8,14 @@ import {
   logoFiDark,
   logoSvDark,
 } from 'hds-react';
-import { useSession, signIn, signOut } from 'next-auth/react';
+import { useSession, signIn } from 'next-auth/react';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 
 import { MAIN_CONTENT_ID, PAGE_HEADER_ID } from '../../../constants';
 import useLocale from '../../../hooks/useLocale';
 import useSelectLanguage from '../../../hooks/useSelectLanguage';
+import useSignOut from '../../../hooks/useSignOut';
 import { ExtendedSession, Language } from '../../../types';
 import { getUserFirstName, getUserName } from '../../auth/utils';
 import useUser from '../../user/hooks/useUser';
@@ -43,10 +44,7 @@ const Header: React.FC = () => {
 
   const { t } = useTranslation('common');
 
-  const handleSignOut = async () => {
-    await signOut();
-    sessionStorage.clear();
-  };
+  const { handleSignOut } = useSignOut();
 
   return (
     <HdsHeader

--- a/src/domain/app/header/__tests__/Header.test.tsx
+++ b/src/domain/app/header/__tests__/Header.test.tsx
@@ -103,7 +103,10 @@ test('should start login process', async () => {
 
 test('should start logout process', async () => {
   const user = userEvent.setup();
-  jest.spyOn(nextAuth, 'signOut').mockImplementation();
+  jest
+    .spyOn(nextAuth, 'signOut')
+    .mockImplementation()
+    .mockResolvedValue({ url: 'https://test.com' });
 
   const username = 'Username';
   const userFirstName = 'User';

--- a/src/domain/app/routes/constants.ts
+++ b/src/domain/app/routes/constants.ts
@@ -6,6 +6,7 @@ export enum ROUTES {
   EDIT_SIGNUP = '/registration/[registrationId]/signup/[signupId]/edit',
   EDIT_SIGNUP_GROUP = '/registration/[registrationId]/signup-group/[signupGroupId]/edit',
   HOME = '/',
+  LOGOUT = '/logout',
   SIGNUP_CANCELLED = '/registration/[registrationId]/signup/cancelled',
   SIGNUP_COMPLETED = '/registration/[registrationId]/signup/[signupId]/completed',
   SIGNUP_GROUP_CANCELLED = '/registration/[registrationId]/signup-group/cancelled',

--- a/src/domain/insufficientPermissions/InsufficientPermissions.tsx
+++ b/src/domain/insufficientPermissions/InsufficientPermissions.tsx
@@ -1,43 +1,14 @@
-import { Button } from 'hds-react';
-import { signOut } from 'next-auth/react';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 
-import ErrorTemplate from '../../common/components/errorTemplate/ErrorTemplate';
-import ErrorPageMeta from '../../common/components/errrorPageMeta/ErrorPageMeta';
-import PageWrapper from '../../common/components/pageWrapper/PageWrapper';
-import MainContent from '../app/layout/mainContent/MainContent';
-
-import styles from './insufficientPermissions.module.scss';
+import ErrorPageWithLogoutButton from '../../common/components/errorPageWithLogoutButton/ErrorPageWithLogoutButton';
 
 const InsufficientPermissions: React.FC = () => {
   const { t } = useTranslation('common');
   const text = t('insufficientPermissions.text');
   const title = t('insufficientPermissions.title');
 
-  return (
-    <PageWrapper>
-      <ErrorPageMeta description={text} title={title} />
-      <MainContent>
-        <ErrorTemplate
-          buttons={
-            <div className={styles.buttons}>
-              <Button
-                fullWidth={true}
-                onClick={() => signOut()}
-                type="button"
-                variant="primary"
-              >
-                {t('signOut')}
-              </Button>
-            </div>
-          }
-          text={text}
-          title={title}
-        />
-      </MainContent>
-    </PageWrapper>
-  );
+  return <ErrorPageWithLogoutButton text={text} title={title} />;
 };
 
 export default InsufficientPermissions;

--- a/src/domain/insufficientPermissions/__tests__/InsufficientPermissions.test.tsx
+++ b/src/domain/insufficientPermissions/__tests__/InsufficientPermissions.test.tsx
@@ -1,40 +1,27 @@
-import * as nextAuth from 'next-auth/react';
 import React from 'react';
 
+import {
+  shouldRenderErrorPageTexts,
+  shouldSignOut,
+} from '../../../common/components/errorPageWithLogoutButton/testUtils';
 import { ExtendedSession } from '../../../types';
-import { configure, render, screen, userEvent } from '../../../utils/testUtils';
-import StrongIdentificationRequired from '../InsufficientPermissions';
+import { configure, render } from '../../../utils/testUtils';
+import InsufficientPermissions from '../InsufficientPermissions';
 
 configure({ defaultHidden: true });
 
 const renderComponent = (session?: ExtendedSession) =>
-  render(<StrongIdentificationRequired />, { session });
-
-const getSignOutButton = () => {
-  return screen.getByRole('button', { name: /kirjaudu ulos/i });
-};
+  render(<InsufficientPermissions />, { session });
 
 test('should render insufficient permissions page', () => {
   renderComponent();
-
-  expect(
-    screen.getByRole('heading', { name: 'Riittämättömät käyttöoikeudet' })
-  ).toBeInTheDocument();
-
-  expect(
-    screen.getByText(
-      'Sinulla ei ole oikeuksia tämän sisällön näkemiseen. Kirjaudu ulos ja kokeile toisella käyttäjätunnuksella.'
-    )
-  ).toBeInTheDocument();
+  shouldRenderErrorPageTexts({
+    text: 'Sinulla ei ole oikeuksia tämän sisällön näkemiseen. Kirjaudu ulos ja kokeile toisella käyttäjätunnuksella.',
+    title: 'Riittämättömät käyttöoikeudet',
+  });
 });
 
-test('should start signIn process', async () => {
-  const user = userEvent.setup();
-  jest.spyOn(nextAuth, 'signOut').mockImplementation();
+test('should start signOut process', async () => {
   renderComponent();
-
-  const signoutButton = getSignOutButton();
-  await user.click(signoutButton);
-
-  expect(nextAuth.signOut).toBeCalled();
+  await shouldSignOut();
 });

--- a/src/domain/logout/LogoutPage.tsx
+++ b/src/domain/logout/LogoutPage.tsx
@@ -1,0 +1,24 @@
+import { useTranslation } from 'next-i18next';
+import React from 'react';
+
+import ErrorTemplate from '../../common/components/errorTemplate/ErrorTemplate';
+import ErrorPageMeta from '../../common/components/errrorPageMeta/ErrorPageMeta';
+import PageWrapper from '../../common/components/pageWrapper/PageWrapper';
+import MainContent from '../app/layout/mainContent/MainContent';
+
+const LogoutPage: React.FC = () => {
+  const { t } = useTranslation('common');
+  const text = t('common:logout.text');
+  const title = t('common:logout.title');
+
+  return (
+    <PageWrapper>
+      <ErrorPageMeta description={text} title={title} />
+      <MainContent>
+        <ErrorTemplate text={text} title={title} />
+      </MainContent>
+    </PageWrapper>
+  );
+};
+
+export default LogoutPage;

--- a/src/domain/logout/__tests__/LogoutPage.test.tsx
+++ b/src/domain/logout/__tests__/LogoutPage.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { configure, render, screen } from '../../../utils/testUtils';
+import LogoutPage from '../LogoutPage';
+
+configure({ defaultHidden: true });
+
+const renderComponent = () => render(<LogoutPage />);
+
+test('should render logout page', () => {
+  renderComponent();
+
+  screen.getByText('Olet kirjautunut ulos palvelusta.');
+});

--- a/src/domain/strongIdentificationRequired/StrongIdentificationRequired.tsx
+++ b/src/domain/strongIdentificationRequired/StrongIdentificationRequired.tsx
@@ -1,44 +1,14 @@
-import { signOut } from 'next-auth/react';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 
-import Button from '../../common/components/button/Button';
-import ErrorTemplate from '../../common/components/errorTemplate/ErrorTemplate';
-import ErrorPageMeta from '../../common/components/errrorPageMeta/ErrorPageMeta';
-import PageWrapper from '../../common/components/pageWrapper/PageWrapper';
-import MainContent from '../app/layout/mainContent/MainContent';
-
-import styles from './strongIdentificationRequired.module.scss';
+import ErrorPageWithLogoutButton from '../../common/components/errorPageWithLogoutButton/ErrorPageWithLogoutButton';
 
 const StrongIdentificationRequired: React.FC = () => {
   const { t } = useTranslation('common');
   const text = t('strongIdentificationRequired.text');
   const title = t('strongIdentificationRequired.title');
 
-  return (
-    <PageWrapper>
-      <ErrorPageMeta description={text} title={title} />
-
-      <MainContent>
-        <ErrorTemplate
-          buttons={
-            <div className={styles.buttons}>
-              <Button
-                fullWidth={true}
-                onClick={() => signOut()}
-                type="button"
-                variant="primary"
-              >
-                {t('signOut')}
-              </Button>
-            </div>
-          }
-          text={text}
-          title={title}
-        />
-      </MainContent>
-    </PageWrapper>
-  );
+  return <ErrorPageWithLogoutButton text={text} title={title} />;
 };
 
 export default StrongIdentificationRequired;

--- a/src/domain/strongIdentificationRequired/__tests__/StrongIdentificationRequired.test.tsx
+++ b/src/domain/strongIdentificationRequired/__tests__/StrongIdentificationRequired.test.tsx
@@ -1,8 +1,12 @@
-import * as nextAuth from 'next-auth/react';
+/* eslint-disable max-len */
 import React from 'react';
 
+import {
+  shouldRenderErrorPageTexts,
+  shouldSignOut,
+} from '../../../common/components/errorPageWithLogoutButton/testUtils';
 import { ExtendedSession } from '../../../types';
-import { configure, render, screen, userEvent } from '../../../utils/testUtils';
+import { configure, render } from '../../../utils/testUtils';
 import StrongIdentificationRequired from '../StrongIdentificationRequired';
 
 configure({ defaultHidden: true });
@@ -10,31 +14,16 @@ configure({ defaultHidden: true });
 const renderComponent = (session?: ExtendedSession) =>
   render(<StrongIdentificationRequired />, { session });
 
-const getSignOutButton = () => {
-  return screen.getByRole('button', { name: /kirjaudu ulos/i });
-};
-
 test('should render strong identification required page', () => {
   renderComponent();
 
-  expect(
-    screen.getByRole('heading', { name: 'Vahva tunnistautuminen vaaditaan' })
-  ).toBeInTheDocument();
-
-  expect(
-    screen.getByText(
-      'Tämän sisällön näkeminen edellyttää vahvaa tunnistautumista. Kirjaudu ulos ja kokeile toista kirjautumistapaa.'
-    )
-  ).toBeInTheDocument();
+  shouldRenderErrorPageTexts({
+    text: 'Tämän sisällön näkeminen edellyttää vahvaa tunnistautumista. Kirjaudu ulos ja kokeile toista kirjautumistapaa.',
+    title: 'Vahva tunnistautuminen vaaditaan',
+  });
 });
 
-test('should start signIn process', async () => {
-  const user = userEvent.setup();
-  jest.spyOn(nextAuth, 'signOut').mockImplementation();
+test('should start signOut process', async () => {
   renderComponent();
-
-  const signoutButton = getSignOutButton();
-  await user.click(signoutButton);
-
-  expect(nextAuth.signOut).toBeCalled();
+  await shouldSignOut();
 });

--- a/src/domain/strongIdentificationRequired/strongIdentificationRequired.module.scss
+++ b/src/domain/strongIdentificationRequired/strongIdentificationRequired.module.scss
@@ -1,7 +1,0 @@
-@import '../../styles/widths.scss';
-
-.buttons {
-  button {
-    @include max-width-column(2);
-  }
-}

--- a/src/hooks/useSignOut.ts
+++ b/src/hooks/useSignOut.ts
@@ -1,0 +1,21 @@
+import { useRouter } from 'next/router';
+import { signOut } from 'next-auth/react';
+
+import { SIGNOUT_REDIRECT } from '../constants';
+
+const useSignOut = () => {
+  const router = useRouter();
+
+  const handleSignOut = async () => {
+    const { url } = await signOut({
+      callbackUrl: SIGNOUT_REDIRECT,
+      redirect: false,
+    });
+    router.push(url);
+    sessionStorage.clear();
+  };
+
+  return { handleSignOut };
+};
+
+export default useSignOut;

--- a/src/pages/logout.tsx
+++ b/src/pages/logout.tsx
@@ -1,0 +1,16 @@
+import { GetServerSideProps, NextPage } from 'next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+
+import Logout from '../domain/logout/LogoutPage';
+
+const LogoutPage: NextPage = () => <Logout />;
+
+export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale as string, ['common'])),
+    },
+  };
+};
+
+export default LogoutPage;


### PR DESCRIPTION
## Description
Redirect user to Tunnistamo `end_session_endpoint` endpoint after sign out

## Closes
[LINK-1738](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1738)

[LINK-1738]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ