### PR TITLE
LINK-1715 | Info texts to signup form

### DIFF
--- a/public/locales/en/signup.json
+++ b/public/locales/en/signup.json
@@ -27,6 +27,7 @@
     "labelNativeLanguage": "Native language",
     "labelPhoneNumber": "Telephone number",
     "labelServiceLanguage": "Language of communication",
+    "notificationTextContactPersonInfo": "Enter your guardian's contact information here if you are a minor.",
     "placeholderEmail": "Enter your email address",
     "placeholderFirstName": "Enter the contact person's first name",
     "placeholderLastName": "Enter the contact person's last name",
@@ -74,7 +75,7 @@
   "labelExtraInfo": "Additional registration information (optional)",
   "labelParticipantAmount": "Number of registrants",
   "labelRegistration": "Registration",
-  "labelUserConsent": "I agree to share my information with the organizer. We do not use the information you provide for marketing purposes. <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Data protection notice {{openInNewTab}}\">Data protection notice</a>",
+  "labelUserConsent": "I agree to share information with the event organizer. The City of Helsinki does not use the information you provide for marketing purposes. <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Data protection notice {{openInNewTab}}\">Data protection notice</a>",
   "linkDataProtectionNotice": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/Kayttajatunnusten%20hallinta.pdf",
   "notifications": {
     "email": "By email",
@@ -91,6 +92,7 @@
   "signupIsEnded": "Registration for the event has ended",
   "signup": {
     "buttonDeleteSignup": "Delete participant",
+    "helperExtraInfo": "Enter here the information about possible allergies, special diets, accessibility or other special needs, if they are information necessary for participating in the event. We forward the information to the event organizer so that the safety and accessibility of the event can be ensured. By entering the data, you give your consent to the processing of the data. You can withdraw your consent by deleting the data.",
     "labelCity": "City",
     "labelDateOfBirth": "Date of birth",
     "labelExtraInfo": "Additional information (optional)",

--- a/public/locales/fi/signup.json
+++ b/public/locales/fi/signup.json
@@ -27,6 +27,7 @@
     "labelNativeLanguage": "Äidinkieli",
     "labelPhoneNumber": "Puhelinnumero",
     "labelServiceLanguage": "Asiointikieli",
+    "notificationTextContactPersonInfo": "Jos olet alaikäinen, syötä tähän huoltajasi yhteystiedot.",
     "placeholderEmail": "Syötä sähköpostiosoite",
     "placeholderFirstName": "Syötä yhteyshenkilön etunimi",
     "placeholderLastName": "Syötä yhteyshenkilön sukunimi",
@@ -74,7 +75,7 @@
   "labelExtraInfo": "Lisätietoa ilmoittautumisesta (valinnainen)",
   "labelParticipantAmount": "Ilmoittautujien määrä",
   "labelRegistration": "Ilmoittautuminen",
-  "labelUserConsent": "Hyväksyn tietojeni jakamisen järjestäjän kanssa. Emme käytä antamiasi tietoja markkinointiin. <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Tietosuojaseloste {{openInNewTab}}\">Tietosuojaseloste</a>",
+  "labelUserConsent": "Hyväksyn tietojen jakamisen tapahtuman järjestäjän kanssa. Helsingin kaupunki ei käytä lomakkeella annettuja tietoja markkinointiin. <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Tietosuojaseloste {{openInNewTab}}\">Tietosuojaseloste</a>",
   "linkDataProtectionNotice": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/Kayttajatunnusten%20hallinta.pdf",
   "notifications": {
     "email": "Sähköpostilla",
@@ -91,6 +92,7 @@
   "signupIsEnded": "Ilmoittautuminen tapahtumaan on päättynyt",
   "signup": {
     "buttonDeleteSignup": "Poista osallistuja",
+    "helperExtraInfo": "Syötä tähän tiedot mahdollisista allergioista, erityisruokavalioista, esteettömyys- tai muista erityistarpeista, mikäli ne on tapahtumaan osallistumisen kannalta tarpeellisia tietoja. Välitämme tiedot tapahtumajärjestäjälle, jotta tapahtuman turvallisuus ja esteettömyys voidaan varmistaa. Syöttämällä tiedot annat suostumuksesi tietojen käsittelyyn. Antamasi suostumuksen voit peruuttaa poistamalla tiedot.",
     "labelCity": "Kaupunki",
     "labelDateOfBirth": "Syntymäaika",
     "labelExtraInfo": "Lisätietoa (valinnainen)",

--- a/public/locales/sv/signup.json
+++ b/public/locales/sv/signup.json
@@ -27,6 +27,7 @@
     "labelNativeLanguage": "Modersmål",
     "labelPhoneNumber": "Telefonnummer",
     "labelServiceLanguage": "Transaktionsspråk",
+    "notificationTextContactPersonInfo": "Ange din vårdnadshavares kontaktuppgifter här om du är minderårig.",
     "placeholderEmail": "Skriv in din mailadress",
     "placeholderFirstName": "Ange kontaktens förnamn",
     "placeholderLastName": "Ange kontaktens efternamn",
@@ -74,7 +75,7 @@
   "labelExtraInfo": "Ytterligare registreringsinformation (valfritt)",
   "labelParticipantAmount": "Antal registrerade",
   "labelRegistration": "Registrering",
-  "labelUserConsent": "Jag godkänner att dela min information med arrangören. Vi använder inte informationen du tillhandahåller för marknadsföringsändamål. <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Registerbeskrivningen {{openInNewTab}}\">Registerbeskrivningen</a>",
+  "labelUserConsent": "Jag godkänner att dela information med evenemangsarrangören. Helsingfors stad använder inte informationen du tillhandahåller för marknadsföringsändamål. <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Registerbeskrivningen {{openInNewTab}}\">Registerbeskrivningen</a>",
   "linkDataProtectionNotice": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/Kayttajatunnusten%20hallinta.pdf",
   "notifications": {
     "email": "Via e-post",
@@ -91,6 +92,7 @@
   "signupIsEnded": "Anmälan till evenemanget är avslutad",
   "signup": {
     "buttonDeleteSignup": "Ta bort deltagare",
+    "helperExtraInfo": "Ange här information om eventuella allergier, specialkost, tillgänglighet eller andra särskilda behov, om det är information som behövs för att delta i evenemanget. Vi vidarebefordrar informationen till arrangören för att evenemangets säkerhet och tillgänglighet kan säkerställas. Genom att ange uppgifterna ger du ditt samtycke till behandlingen av uppgifterna. Du kan återkalla ditt samtycke genom att radera uppgifterna.",
     "labelCity": "Staden",
     "labelDateOfBirth": "Födelsedatum",
     "labelExtraInfo": "Ytterligare information (valfritt)",

--- a/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
+++ b/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
@@ -17,6 +17,7 @@ import TextAreaField from '../../../common/components/formFields/TextAreaField';
 import TextInputField from '../../../common/components/formFields/TextInputField';
 import FormGroup from '../../../common/components/formGroup/FormGroup';
 import FormikPersist from '../../../common/components/formikPersist/FormikPersist';
+import Notification from '../../../common/components/notification/Notification';
 import { useNotificationsContext } from '../../../common/components/notificationsContext/hooks/useNotificationsContext';
 import ServerErrorSummary from '../../../common/components/serverErrorSummary/ServerErrorSummary';
 import { FORM_NAMES, READ_ONLY_PLACEHOLDER } from '../../../constants';
@@ -357,9 +358,16 @@ const SignupGroupForm: React.FC<Props> = ({
                     registration={registration}
                   />
 
-                  <h2 className={styles.sectionTitle}>
-                    {t('contactPerson.titleContactPersonInfo')}
-                  </h2>
+                  <FormGroup>
+                    <h2 className={styles.sectionTitle}>
+                      {t('contactPerson.titleContactPersonInfo')}
+                    </h2>
+                  </FormGroup>
+                  <Notification type="info">
+                    <p style={{ margin: 0 }}>
+                      {t('contactPerson.notificationTextContactPersonInfo')}
+                    </p>
+                  </Notification>
                   <Divider />
 
                   {contactPersonFieldsDisabled && signup && (

--- a/src/domain/signupGroup/signupGroupForm/signups/signup/Signup.tsx
+++ b/src/domain/signupGroup/signupGroupForm/signups/signup/Signup.tsx
@@ -168,6 +168,7 @@ const Signup: React.FC<Props> = ({
           className={styles.extraInfoField}
           component={TextAreaField}
           disabled={formDisabled}
+          helperText={t(`signup.helperExtraInfo`)}
           label={t(`signup.labelExtraInfo`)}
           placeholder={getPlaceholder(t(`signup.placeholderExtraInfo`))}
           readOnly={readOnly}

--- a/src/domain/signupGroup/summaryPage/SummaryPage.tsx
+++ b/src/domain/signupGroup/summaryPage/SummaryPage.tsx
@@ -203,6 +203,7 @@ const SummaryPage: FC<SummaryPageProps> = ({ event, registration }) => {
                     <Notification
                       className={styles.notification}
                       label={t('notificationTitle')}
+                      type="info"
                     >
                       {t('notificationLabel')}
                     </Notification>

--- a/src/domain/signupGroup/testUtils.ts
+++ b/src/domain/signupGroup/testUtils.ts
@@ -29,7 +29,7 @@ export const getSignupFormElement = (
   switch (key) {
     case 'acceptCheckbox':
       return screen.getByLabelText(
-        /hyväksyn tietojeni jakamisen järjestäjän kanssa/i
+        /Hyväksyn tietojen jakamisen tapahtuman järjestäjän kanssa./i
       );
     case 'cancelButton':
       return screen.getByRole('button', { name: /peruuta ilmoittautuminen/i });


### PR DESCRIPTION
## Description :sparkles:
Add helper text for signup extra info field and notification for contact person section
Update user consent text

## Closes
[LINK-1715](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1715)

## Screenshots
<img width="725" alt="Screenshot 2023-11-23 at 12 37 56" src="https://github.com/City-of-Helsinki/linkedregistrations-ui/assets/24706814/c340bee2-3e90-4570-b090-0d9f6637ef20">
<img width="724" alt="Screenshot 2023-11-23 at 12 38 01" src="https://github.com/City-of-Helsinki/linkedregistrations-ui/assets/24706814/c3f9fd82-fc4a-4ac8-9310-888ac424c398">
<img width="716" alt="Screenshot 2023-11-23 at 12 38 08" src="https://github.com/City-of-Helsinki/linkedregistrations-ui/assets/24706814/af81ad5b-edf9-4cde-b686-b4a5deebdd4e">



[LINK-1715]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ