### PR TITLE
LINK-1777 | Remove mandatory fields validation from contact person fields

### DIFF
--- a/src/domain/signupGroup/__tests__/validation.test.ts
+++ b/src/domain/signupGroup/__tests__/validation.test.ts
@@ -72,11 +72,10 @@ const testSignupSchema = async (
 };
 
 const testContactPersonSchema = async (
-  registration: Registration,
   contactPerson: ContactPersonFormFields
 ) => {
   try {
-    await getContactPersonSchema(registration).validate(contactPerson);
+    await getContactPersonSchema().validate(contactPerson);
     return true;
   } catch (e) {
     return false;
@@ -280,7 +279,6 @@ describe('signupSchema function', () => {
 });
 
 describe('getContactPersonSchema function', () => {
-  const registration = fakeRegistration();
   const validContactPerson: ContactPersonFormFields = {
     email: 'user@email.com',
     firstName: 'First name',
@@ -293,15 +291,13 @@ describe('getContactPersonSchema function', () => {
     serviceLanguage: 'fi',
   };
 
-  test('should return true if contac person data is valid', async () => {
-    expect(
-      await testContactPersonSchema(registration, validContactPerson)
-    ).toBe(true);
+  test('should return true if contact person data is valid', async () => {
+    expect(await testContactPersonSchema(validContactPerson)).toBe(true);
   });
 
   test('should return false if email is missing', async () => {
     expect(
-      await testContactPersonSchema(registration, {
+      await testContactPersonSchema({
         ...validContactPerson,
         email: '',
       })
@@ -310,7 +306,7 @@ describe('getContactPersonSchema function', () => {
 
   test('should return false if email is invalid', async () => {
     expect(
-      await testContactPersonSchema(registration, {
+      await testContactPersonSchema({
         ...validContactPerson,
         email: 'user@email.',
       })
@@ -319,7 +315,7 @@ describe('getContactPersonSchema function', () => {
 
   test('should return false if phone number is missing', async () => {
     expect(
-      await testContactPersonSchema(registration, {
+      await testContactPersonSchema({
         ...validContactPerson,
         phoneNumber: '',
         notifications: [NOTIFICATIONS.SMS],
@@ -329,16 +325,17 @@ describe('getContactPersonSchema function', () => {
 
   test('should return false if phone number is invalid', async () => {
     expect(
-      await testContactPersonSchema(registration, {
+      await testContactPersonSchema({
         ...validContactPerson,
         phoneNumber: 'xxx',
+        notifications: [NOTIFICATIONS.SMS],
       })
     ).toBe(false);
   });
 
   test('should return false if notifications is empty array', async () => {
     expect(
-      await testContactPersonSchema(registration, {
+      await testContactPersonSchema({
         ...validContactPerson,
         notifications: [],
       })
@@ -347,7 +344,7 @@ describe('getContactPersonSchema function', () => {
 
   test('should return false if native language is empty', async () => {
     expect(
-      await testContactPersonSchema(registration, {
+      await testContactPersonSchema({
         ...validContactPerson,
         nativeLanguage: '',
       })
@@ -356,34 +353,10 @@ describe('getContactPersonSchema function', () => {
 
   test('should return false if service language is empty', async () => {
     expect(
-      await testContactPersonSchema(registration, {
+      await testContactPersonSchema({
         ...validContactPerson,
         serviceLanguage: '',
       })
-    ).toBe(false);
-  });
-
-  test('should return false if membership number is set as mandatory field but value is empty', async () => {
-    expect(
-      await testContactPersonSchema(
-        fakeRegistration({ mandatory_fields: ['membership_number'] }),
-        {
-          ...validContactPerson,
-          membershipNumber: '',
-        }
-      )
-    ).toBe(false);
-  });
-
-  test('should return false if phone number is set as mandatory field but value is empty', async () => {
-    expect(
-      await testContactPersonSchema(
-        fakeRegistration({ mandatory_fields: ['phone_number'] }),
-        {
-          ...validContactPerson,
-          phoneNumber: '',
-        }
-      )
     ).toBe(false);
   });
 });
@@ -417,10 +390,7 @@ describe('testSignupGroupSchema function', () => {
     expect(
       await testSignupGroupSchema(registration, {
         ...validSignupGroup,
-        contactPerson: {
-          ...validSignupGroup.contactPerson,
-          email: '',
-        },
+        contactPerson: { ...validSignupGroup.contactPerson, email: '' },
       })
     ).toBe(false);
   });
@@ -457,6 +427,7 @@ describe('testSignupGroupSchema function', () => {
         contactPerson: {
           ...validSignupGroup.contactPerson,
           phoneNumber: 'xxx',
+          notifications: [NOTIFICATIONS.SMS],
         },
       })
     ).toBe(false);
@@ -466,10 +437,7 @@ describe('testSignupGroupSchema function', () => {
     expect(
       await testSignupGroupSchema(registration, {
         ...validSignupGroup,
-        contactPerson: {
-          ...validSignupGroup.contactPerson,
-          notifications: [],
-        },
+        contactPerson: { ...validSignupGroup.contactPerson, notifications: [] },
       })
     ).toBe(false);
   });
@@ -495,48 +463,6 @@ describe('testSignupGroupSchema function', () => {
           serviceLanguage: '',
         },
       })
-    ).toBe(false);
-  });
-
-  test('should return false if membership number is set as mandatory field but value is empty', async () => {
-    expect(
-      await testSignupGroupSchema(
-        fakeRegistration({ mandatory_fields: ['membership_number'] }),
-        {
-          ...validSignupGroup,
-          contactPerson: {
-            ...validSignupGroup.contactPerson,
-            membershipNumber: '',
-          },
-        }
-      )
-    ).toBe(false);
-  });
-
-  test('should return false if extra info is set as mandatory field but value is empty', async () => {
-    expect(
-      await testSignupGroupSchema(
-        fakeRegistration({ mandatory_fields: ['extra_info'] }),
-        {
-          ...validSignupGroup,
-          extraInfo: '',
-        }
-      )
-    ).toBe(false);
-  });
-
-  test('should return false if phone number is set as mandatory field but value is empty', async () => {
-    expect(
-      await testSignupGroupSchema(
-        fakeRegistration({ mandatory_fields: ['phone_number'] }),
-        {
-          ...validSignupGroup,
-          contactPerson: {
-            ...validSignupGroup.contactPerson,
-            phoneNumber: '',
-          },
-        }
-      )
     ).toBe(false);
   });
 });

--- a/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
+++ b/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
@@ -423,7 +423,6 @@ const SignupGroupForm: React.FC<Props> = ({
                             t(`contactPerson.placeholderFirstName`)
                           )}
                           readOnly={readOnly}
-                          required
                           title={titleCannotEditContactPerson}
                         />
                         <Field
@@ -437,10 +436,6 @@ const SignupGroupForm: React.FC<Props> = ({
                             t(`contactPerson.placeholderLastName`)
                           )}
                           readOnly={readOnly}
-                          required={isSignupFieldRequired(
-                            registration,
-                            CONTACT_PERSON_FIELDS.LAST_NAME
-                          )}
                           title={titleCannotEditContactPerson}
                         />
                       </div>
@@ -480,10 +475,6 @@ const SignupGroupForm: React.FC<Props> = ({
                             t(`contactPerson.placeholderMembershipNumber`)
                           )}
                           readOnly={readOnly}
-                          required={isSignupFieldRequired(
-                            registration,
-                            CONTACT_PERSON_FIELDS.MEMBERSHIP_NUMBER
-                          )}
                           title={titleCannotEditContactPerson}
                         />
                       </div>

--- a/src/domain/signupGroup/validation.ts
+++ b/src/domain/signupGroup/validation.ts
@@ -107,14 +107,12 @@ export const getSignupSchema = (registration: Registration) => {
   });
 };
 
-export const getContactPersonSchema = (registration: Registration) => {
+export const getContactPersonSchema = () => {
   return Yup.object().shape({
-    [CONTACT_PERSON_FIELDS.EMAIL]: Yup.string()
-      .email(VALIDATION_MESSAGE_KEYS.EMAIL)
-      .required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED),
-    [CONTACT_PERSON_FIELDS.PHONE_NUMBER]: getStringSchema(
-      isSignupFieldRequired(registration, CONTACT_PERSON_FIELDS.PHONE_NUMBER)
-    )
+    [CONTACT_PERSON_FIELDS.EMAIL]: getStringSchema(true).email(
+      VALIDATION_MESSAGE_KEYS.EMAIL
+    ),
+    [CONTACT_PERSON_FIELDS.PHONE_NUMBER]: getStringSchema(false)
       .test(
         'isValidPhoneNumber',
         VALIDATION_MESSAGE_KEYS.PHONE,
@@ -132,21 +130,10 @@ export const getContactPersonSchema = (registration: Registration) => {
       .min(1, (param) =>
         createMinErrorMessage(param, VALIDATION_MESSAGE_KEYS.ARRAY_MIN)
       ),
-    [CONTACT_PERSON_FIELDS.MEMBERSHIP_NUMBER]: getStringSchema(
-      isSignupFieldRequired(
-        registration,
-        CONTACT_PERSON_FIELDS.MEMBERSHIP_NUMBER
-      )
-    ),
-    [CONTACT_PERSON_FIELDS.NATIVE_LANGUAGE]: Yup.string().required(
-      VALIDATION_MESSAGE_KEYS.STRING_REQUIRED
-    ),
-    [CONTACT_PERSON_FIELDS.SERVICE_LANGUAGE]: Yup.string().required(
-      VALIDATION_MESSAGE_KEYS.STRING_REQUIRED
-    ),
-    [SIGNUP_GROUP_FIELDS.EXTRA_INFO]: getStringSchema(
-      isSignupFieldRequired(registration, SIGNUP_GROUP_FIELDS.EXTRA_INFO)
-    ),
+    [CONTACT_PERSON_FIELDS.MEMBERSHIP_NUMBER]: getStringSchema(false),
+    [CONTACT_PERSON_FIELDS.NATIVE_LANGUAGE]: getStringSchema(true),
+    [CONTACT_PERSON_FIELDS.SERVICE_LANGUAGE]: getStringSchema(true),
+    [SIGNUP_GROUP_FIELDS.EXTRA_INFO]: getStringSchema(false),
   });
 };
 
@@ -159,8 +146,7 @@ export const getSignupGroupSchema = (
       getSignupSchema(registration)
     ),
     ...(validateContactPerson && {
-      [SIGNUP_GROUP_FIELDS.CONTACT_PERSON]:
-        getContactPersonSchema(registration),
+      [SIGNUP_GROUP_FIELDS.CONTACT_PERSON]: getContactPersonSchema(),
     }),
     [SIGNUP_GROUP_FIELDS.EXTRA_INFO]: getStringSchema(
       isSignupFieldRequired(registration, SIGNUP_GROUP_FIELDS.EXTRA_INFO)


### PR DESCRIPTION
## Description
API doesn't support mandatory fields validation for contact person fields so remove it here as well

## Closes
[LINK-1777](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1777)


[LINK-1777]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ