### PR TITLE
LINK-1823 | Improve performance on server side

### DIFF
--- a/src/domain/registration/constants.tsx
+++ b/src/domain/registration/constants.tsx
@@ -12,6 +12,7 @@ export enum REGISTRATION_MANDATORY_FIELDS {
 export const TEST_REGISTRATION_ID = 'registration:1';
 
 export const REGISTRATION_INCLUDES = ['event', 'keywords', 'location'];
+export const REGISTRATION_INCLUDES_SERVER = ['event', 'keywords'];
 
 export enum REGISTRATION_ACTIONS {
   EXPORT_SIGNUPS_AS_EXCEL = 'exportSignupsAsExcel',

--- a/src/domain/registration/types.ts
+++ b/src/domain/registration/types.ts
@@ -43,6 +43,7 @@ export type RegistrationsResponse = {
 export type RegistrationQueryVariables = {
   id: string;
   include?: string[];
+  nocache?: boolean;
 };
 
 export type RegistrationFields = {

--- a/src/domain/registration/utils.ts
+++ b/src/domain/registration/utils.ts
@@ -9,7 +9,7 @@ import { NotificationProps } from '../../common/components/notification/Notifica
 import { VALIDATION_MESSAGE_KEYS } from '../../constants';
 import { ExtendedSession, Language } from '../../types';
 import getLocalisedString from '../../utils/getLocalisedString';
-import queryBuilder from '../../utils/queryBuilder';
+import queryBuilder, { VariableToKeyItem } from '../../utils/queryBuilder';
 import { callGet } from '../app/axios/axiosClient';
 import {
   getSeatsReservationData,
@@ -44,14 +44,18 @@ export const fetchRegistration = async (
   }
 };
 
-export const registrationPathBuilder = (
-  args: RegistrationQueryVariables
-): string => {
+export const registrationPathBuilder = ({
+  nocache = true,
+  ...args
+}: RegistrationQueryVariables): string => {
   const { id, include } = args;
-  const variableToKeyItems = [
+  const variableToKeyItems: VariableToKeyItem[] = [
     { key: 'include', value: include },
-    { key: 'nocache', value: true },
   ];
+
+  if (nocache) {
+    variableToKeyItems.push({ key: 'nocache', value: nocache });
+  }
 
   const query = queryBuilder(variableToKeyItems);
 

--- a/src/utils/generateGetServerSideProps.ts
+++ b/src/utils/generateGetServerSideProps.ts
@@ -1,14 +1,19 @@
 /* eslint-disable no-console */
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import { GetServerSideProps } from 'next';
+import { getServerSession, NextAuthOptions } from 'next-auth';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 
 import { RegistrationQueryVariables } from '../domain/registration/types';
 import { prefetchSignupQuery } from '../domain/signup/query';
 import { prefetchSignupGroupQuery } from '../domain/signupGroup/query';
-import { ExtendedSSRConfig, TranslationNamespaces } from '../types';
+import { getNextAuthOptions } from '../pages/api/auth/[...nextauth]';
+import {
+  ExtendedSession,
+  ExtendedSSRConfig,
+  TranslationNamespaces,
+} from '../types';
 
-import { getSessionAndUser } from './getSessionAndUser';
 import prefetchRegistrationAndEvent from './prefetchRegistrationAndEvent';
 
 type Props = {
@@ -19,7 +24,7 @@ type Props = {
   translationNamespaces: TranslationNamespaces;
 };
 
-const generateSignupGetServerSideProps = ({
+const generateGetServerSideProps = ({
   overrideRegistrationsVariables,
   shouldPrefetchPlace,
   shouldPrefetchSignup,
@@ -28,10 +33,11 @@ const generateSignupGetServerSideProps = ({
 }: Props): GetServerSideProps<ExtendedSSRConfig> => {
   return async ({ locale, query, req, res }) => {
     const queryClient = new QueryClient();
-    const { session } = await getSessionAndUser(queryClient, {
+    const session = await getServerSession<NextAuthOptions, ExtendedSession>(
       req,
       res,
-    });
+      getNextAuthOptions()
+    );
 
     await prefetchRegistrationAndEvent({
       overrideRegistrationsVariables,
@@ -81,4 +87,4 @@ const generateSignupGetServerSideProps = ({
   };
 };
 
-export default generateSignupGetServerSideProps;
+export default generateGetServerSideProps;

--- a/src/utils/prefetchRegistrationAndEvent.ts
+++ b/src/utils/prefetchRegistrationAndEvent.ts
@@ -2,7 +2,7 @@
 import { QueryClient } from '@tanstack/react-query';
 import { NextParsedUrlQuery } from 'next/dist/server/request-meta';
 
-import { REGISTRATION_INCLUDES } from '../domain/registration/constants';
+import { REGISTRATION_INCLUDES_SERVER } from '../domain/registration/constants';
 import { fetchRegistrationQuery } from '../domain/registration/query';
 import { RegistrationQueryVariables } from '../domain/registration/types';
 import { ExtendedSession } from '../types';
@@ -23,7 +23,8 @@ const prefetchRegistrationAndEvent = async ({
     await fetchRegistrationQuery({
       args: {
         id: query.registrationId as string,
-        include: REGISTRATION_INCLUDES,
+        include: REGISTRATION_INCLUDES_SERVER,
+        nocache: false,
         ...overrideRegistrationsVariables,
       },
       queryClient,


### PR DESCRIPTION
## Description
Request only data that is needed for meta data in the server side
- Don’t request user from LE API 
- Drop location from include param value because event place is not used by the meta data
- Drop nocache=true from registration params to get registration from cache if possible

## Closes
[LINK-1823](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1823)

[LINK-1823]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ