### PR TITLE
LINK-1853 | Add timeout to SingleSelectComponent value change

### DIFF
--- a/src/common/components/formFields/SingleSelectField.tsx
+++ b/src/common/components/formFields/SingleSelectField.tsx
@@ -25,9 +25,13 @@ const SingleSelectField: React.FC<Props> = ({
   };
 
   const handleChange = (selected: OptionType) => {
-    onChange({
-      target: { id: name, value: selected.value },
-    });
+    // Set timeout to prevent Android devices to end up
+    // to an infinite loop when changing value
+    setTimeout(() => {
+      onChange({
+        target: { id: name, value: selected.value },
+      });
+    }, 5);
   };
 
   return (


### PR DESCRIPTION
## Description
- Android devices freezes totally when trying to change value of a SingleSelectComponent. Add a short timeout to prevent infinite loop after calling onChange.

## Closes
[LINK-1853](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1853)

[LINK-1853]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ