### PR TITLE
LINK-1820 | Display enrolment start time when registration is closed

### DIFF
--- a/public/locales/en/signup.json
+++ b/public/locales/en/signup.json
@@ -121,6 +121,7 @@
     "capacityInWaitingList": "Registration for this event is still possible, but there are only {{count}} seat left in the queue.",
     "capacityInWaitingList_other": "Registration for this event is still possible, but there are only {{count}} seats left in the queue.",
     "capacityInWaitingListNoLimit": "Registration for this event is still possible, but there are only seats left in the queue.",
-    "closed": "Registration for this event is currently closed. Please try again later."
+    "closed": "Registration for this event is currently closed. Please try again later.",
+    "closedWithEnrolmentTime": "Registration for this event opens on {{openingDate}} at {{openingTime}}."
   }
 }

--- a/public/locales/fi/signup.json
+++ b/public/locales/fi/signup.json
@@ -120,6 +120,7 @@
     "capacityInWaitingList": "Ilmoittautuminen tähän tapahtumaan on vielä mahdollista, mutta jonopaikkoja on jäljellä vain {{count}} kpl.",
     "capacityInWaitingList_other": "Ilmoittautuminen tähän tapahtumaan on vielä mahdollista, mutta jonopaikkoja on jäljellä vain {{count}} kpl.",
     "capacityInWaitingListNoLimit": "Ilmoittautuminen tähän tapahtumaan on vielä mahdollista, mutta vain jonopaikkoja on jäljellä.",
-    "closed": "Ilmoittautuminen tähän tapahtumaan on tällä hetkellä suljettu. Kokeile myöhemmin uudelleen."
+    "closed": "Ilmoittautuminen tähän tapahtumaan on tällä hetkellä suljettu. Kokeile myöhemmin uudelleen.",
+    "closedWithEnrolmentTime": "Ilmoittautuminen tähän tapahtumaan avautuu {{openingDate}} klo {{openingTime}}."
   }
 }

--- a/public/locales/sv/signup.json
+++ b/public/locales/sv/signup.json
@@ -120,6 +120,7 @@
     "capacityInWaitingList": "Registrering för detta evenemang är fortfarande möjligt, men det är bara {{count}} plats kvar i kön.",
     "capacityInWaitingList_other": "Registrering för detta evenemang är fortfarande möjligt, men det är bara {{count}} platser kvar i kön.",
     "capacityInWaitingListNoLimit": "Registrering till detta evenemang är fortfarande möjlig, men det finns endast platser kvar i kön.",
-    "closed": "Registreringen för detta evenemang är för närvarande stängd. Vänligen försök igen senare."
+    "closed": "Registreringen för detta evenemang är för närvarande stängd. Vänligen försök igen senare.",
+    "closedWithEnrolmentTime": "Anmälan till detta evenemang öppnar den {{openingDate}} kl {{openingTime}}."
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,6 +25,7 @@ export const PAGE_HEADER_ID = 'page-header';
 export const MAIN_CONTENT_ID = 'maincontent';
 
 export const DATE_FORMAT = 'd.M.yyyy';
+export const TIME_FORMAT = 'HH.mm';
 
 export enum RESERVATION_NAMES {
   SIGNUP_RESERVATION = 'signup-reservation',

--- a/src/domain/registration/__tests__/utils.test.ts
+++ b/src/domain/registration/__tests__/utils.test.ts
@@ -67,6 +67,17 @@ describe('getRegistrationWarning', () => {
         }),
         i18n.t.bind(i18n)
       )
+    ).toBe('Ilmoittautuminen tähän tapahtumaan avautuu 4.11.2022 klo 00.00.');
+
+    expect(
+      getRegistrationWarning(
+        fakeRegistration({
+          ...singleRegistrationOverrides,
+          enrolment_start_time: '',
+          enrolment_end_time: new Date('2022-11-06').toISOString(),
+        }),
+        i18n.t.bind(i18n)
+      )
     ).toBe(
       'Ilmoittautuminen tähän tapahtumaan on tällä hetkellä suljettu. Kokeile myöhemmin uudelleen.'
     );

--- a/src/domain/registration/utils.ts
+++ b/src/domain/registration/utils.ts
@@ -6,8 +6,9 @@ import { TFunction } from 'next-i18next';
 
 import { MenuItemOptionProps } from '../../common/components/menuDropdown/types';
 import { NotificationProps } from '../../common/components/notification/Notification';
-import { VALIDATION_MESSAGE_KEYS } from '../../constants';
+import { TIME_FORMAT, VALIDATION_MESSAGE_KEYS } from '../../constants';
 import { ExtendedSession, Language } from '../../types';
+import formatDate from '../../utils/formatDate';
 import getLocalisedString from '../../utils/getLocalisedString';
 import queryBuilder, { VariableToKeyItem } from '../../utils/queryBuilder';
 import { callGet } from '../app/axios/axiosClient';
@@ -202,6 +203,13 @@ export const getRegistrationWarning = (
   const freeWaitlistCapacity = getFreeWaitingListCapacity(registration);
 
   if (!registrationOpen) {
+    if (registration.enrolment_start_time) {
+      const enrolmentStartTime = new Date(registration.enrolment_start_time);
+      return t('signup:warnings.closedWithEnrolmentTime', {
+        openingDate: formatDate(enrolmentStartTime),
+        openingTime: formatDate(enrolmentStartTime, TIME_FORMAT),
+      });
+    }
     return t('signup:warnings.closed');
   }
 

--- a/src/domain/signupGroup/CreateSignupGroupPage.tsx
+++ b/src/domain/signupGroup/CreateSignupGroupPage.tsx
@@ -16,8 +16,10 @@ import SignupPageMeta from '../signup/signupPageMeta/SignupPageMeta';
 import { SignupServerErrorsProvider } from '../signup/signupServerErrorsContext/SignupServerErrorsContext';
 
 import AuthenticationRequiredNotification from './authenticationRequiredNotification/AuthenticationRequiredNotification';
+import Divider from './divider/Divider';
 import EventInfo from './eventInfo/EventInfo';
 import FormContainer from './formContainer/FormContainer';
+import RegistrationWarning from './registrationWarning/RegistrationWarning';
 import SignupGroupForm from './signupGroupForm/SignupGroupForm';
 import { SignupGroupFormProvider } from './signupGroupFormContext/SignupGroupFormContext';
 import SignupIsEnded from './signupIsEnded/SignupIsEnded';
@@ -42,6 +44,8 @@ const CreateSignupGroupPage: React.FC<Props> = ({ event, registration }) => {
           <FormContainer>
             {<AuthenticationRequiredNotification />}
             <EventInfo event={event} registration={registration} />
+            <Divider />
+            <RegistrationWarning registration={registration} />
           </FormContainer>
         </Container>
       )}


### PR DESCRIPTION
## Description :sparkles:
Display enrolment start time when registration is closed

## Closes
[LINK-1820](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1820)

## Screenshot
<img width="664" alt="Screenshot 2024-01-16 at 15 34 59" src="https://github.com/City-of-Helsinki/linkedregistrations-ui/assets/24706814/3cec96fe-ee47-4e58-b36a-a406f1e2c18a">


[LINK-1820]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ