### PR TITLE
LINK-1878 | Fix JWT verification failed error

### DIFF
--- a/src/common/components/formikPersist/FormikPersist.tsx
+++ b/src/common/components/formikPersist/FormikPersist.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-undef */
 import { FormikProps, useFormikContext } from 'formik';
-import { getSession } from 'next-auth/react';
 import * as React from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 
@@ -29,9 +28,7 @@ const FormikPersist = ({
 
   const debouncedSaveForm = useDebouncedCallback(
     async (data: FormikProps<Record<string, unknown>>) => {
-      const session = await getSession();
-      /* istanbul ignore next */
-      if (!session || savingDisabled || !isMounted.current) return;
+      if (savingDisabled || !isMounted.current) return;
 
       if (isSessionStorage) {
         window.sessionStorage.setItem(name, JSON.stringify(data));

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -48,10 +48,7 @@ const MyApp = ({
 
   return (
     <NotificationsProvider>
-      <SessionProvider
-        session={session}
-        refetchInterval={/* 5 minutes */ 5 * 60}
-      >
+      <SessionProvider session={session} refetchInterval={30}>
         <QueryClientProvider client={queryClient}>
           <Hydrate state={pageProps.dehydratedState}>
             <CookieConsent />

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -25,6 +25,8 @@ import {
 } from '../../../types';
 import getServerRuntimeConfig from '../../../utils/getServerRuntimeConfig';
 
+const REFRESH_THRESHOLD_SECONDS = 60;
+
 type JwtParams = {
   token: ExtendedJWT;
   user?: OidcUser;
@@ -133,7 +135,10 @@ export const jwtCallback = async (params: {
     };
   }
 
-  if (token.accessTokenExpires && Date.now() < token.accessTokenExpires) {
+  if (
+    token.accessTokenExpires &&
+    Date.now() < token.accessTokenExpires - REFRESH_THRESHOLD_SECONDS * 1000
+  ) {
     return token;
   }
 


### PR DESCRIPTION
## Description
- Currently next-auth session refresh interval is 5 minutes. However, the expiration time for the api token is 5 minutes as well. So the api token is getting old before the api token is refreshed. Also refresh api token 60 seconds before expiration time.
- Getting session by using getSession functions sends request to server every time that form state is saved. It's redundant to check session state here anyway so remove the check totally

## Closes
[LINK-1878](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1878)

[LINK-1878]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ