### PR TITLE
 LINK-1848 | prioritise most used language options

### DIFF
--- a/src/domain/language/hooks/__tests__/useLanguageOptions.test.tsx
+++ b/src/domain/language/hooks/__tests__/useLanguageOptions.test.tsx
@@ -14,15 +14,15 @@ test('should return language options', async () => {
   await waitFor(() => expect(result.current.length).toBeTruthy());
 
   expect(result.current).toEqual([
-    { label: 'Arabia', value: 'ar' },
+    { label: 'Suomi', value: 'fi' },
+    { label: 'Ruotsi', value: 'sv' },
     { label: 'Englanti', value: 'en' },
+    { label: 'Arabia', value: 'ar' },
     { label: 'Espanja', value: 'es' },
     { label: 'Kiina', value: 'zh_hans' },
     { label: 'Persia', value: 'fa' },
     { label: 'Ranska', value: 'fr' },
-    { label: 'Ruotsi', value: 'sv' },
     { label: 'Somali', value: 'so' },
-    { label: 'Suomi', value: 'fi' },
     { label: 'Turkki', value: 'tr' },
     { label: 'Venäjä', value: 'ru' },
     { label: 'Viro', value: 'et' },
@@ -41,9 +41,9 @@ test('should return service language options', async () => {
   await waitFor(() => expect(result.current.length).toBeTruthy());
 
   expect(result.current).toEqual([
-    { label: 'Englanti', value: 'en' },
-    { label: 'Ruotsi', value: 'sv' },
     { label: 'Suomi', value: 'fi' },
+    { label: 'Ruotsi', value: 'sv' },
+    { label: 'Englanti', value: 'en' },
   ]);
 });
 

--- a/src/domain/language/utils.ts
+++ b/src/domain/language/utils.ts
@@ -1,5 +1,6 @@
 import { AxiosError } from 'axios';
-import { capitalize } from 'lodash';
+import capitalize from 'lodash/capitalize';
+import get from 'lodash/get';
 
 import { OptionType, Language, ExtendedSession } from '../../types';
 import getLocalisedString from '../../utils/getLocalisedString';
@@ -47,5 +48,17 @@ export const getLanguageOption = (
   value: language.id,
 });
 
-export const sortLanguageOptions = (a: OptionType, b: OptionType): number =>
-  a.label > b.label ? 1 : -1;
+export const sortLanguageOptions = (a: OptionType, b: OptionType): number => {
+  const languagePriorities = {
+    fi: 3,
+    sv: 2,
+    en: 1,
+  };
+  const aPriority = get(languagePriorities, a.value, 0);
+  const bPriority = get(languagePriorities, b.value, 0);
+
+  if (aPriority !== bPriority) {
+    return bPriority - aPriority;
+  }
+  return a.label.localeCompare(b.label, undefined, { sensitivity: 'base' });
+};


### PR DESCRIPTION
## Description
Prioritise most used languages in the Native language and Service language dropdown in the signup form

## Closes
[LINK-1848](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1848)

## Screenshot
<img width="857" alt="Screenshot 2024-02-02 at 11 52 07" src="https://github.com/City-of-Helsinki/linkedregistrations-ui/assets/24706814/bd55ebaf-0685-4d0e-a516-d754dac48a30">


[LINK-1848]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ