### PR TITLE
fix: use checkout url with user info

### DIFF
--- a/src/domain/signupGroup/summaryPage/SummaryPage.tsx
+++ b/src/domain/signupGroup/summaryPage/SummaryPage.tsx
@@ -89,7 +89,7 @@ const SummaryPage: FC<SummaryPageProps> = ({ event, registration }) => {
   };
 
   const goToPaymentPage = (payment: Payment) => {
-    window.open(payment.logged_in_checkout_url, '_self', 'noopener,noreferrer');
+    window.open(payment.checkout_url, '_self', 'noopener,noreferrer');
   };
   const goToSignupCompletedPage = (signupId: string) => {
     clearTimerAndStorage();


### PR DESCRIPTION
## Description
Use checkout url which contains user id when moving to Talpa payment to avoid issues when user is authenticated with Helsinki-tunnus