### PR TITLE
fix: replace undefined with null in user data

### DIFF
--- a/src/__tests__/NextAuth.test.ts
+++ b/src/__tests__/NextAuth.test.ts
@@ -199,7 +199,7 @@ describe('jwtCallback function', () => {
     expect(jwt).toEqual(token);
   });
 
-  test('should return undefined if refreshing token fails', async () => {
+  test('should return null if refreshing token fails', async () => {
     advanceTo('2023-01-01');
 
     jest
@@ -210,7 +210,7 @@ describe('jwtCallback function', () => {
       token: { ...token, accessTokenExpires: 1662531200000 },
     });
 
-    expect(jwt).toEqual(undefined);
+    expect(jwt).toEqual(null);
   });
 
   test('should refresh api token', async () => {

--- a/src/domain/signupGroup/reservationTimer/ReservationTimer.tsx
+++ b/src/domain/signupGroup/reservationTimer/ReservationTimer.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 import pick from 'lodash/pick';
 import { useRouter } from 'next/router';
-import { getSession } from 'next-auth/react';
+import { useSession } from 'next-auth/react';
 import { useTranslation } from 'next-i18next';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 
@@ -65,6 +65,7 @@ const ReservationTimer: React.FC<ReservationTimerProps> = ({
   signups,
 }) => {
   const isExpiringModalAlreadyDisplayed = useRef(false);
+  const { data: session } = useSession();
   const router = useRouter();
   const { t } = useTranslation('reservation');
   const { setAccessibilityText } = useAccessibilityNotificationContext();
@@ -149,7 +150,7 @@ const ReservationTimer: React.FC<ReservationTimerProps> = ({
             }
           },
         });
-      } else if (!data) {
+      } else {
         onDataNotFound && onDataNotFound();
       }
     } else if (data) {
@@ -170,7 +171,6 @@ const ReservationTimer: React.FC<ReservationTimerProps> = ({
     const clearDataIfReservationExpired = async () => {
       /* istanbul ignore else */
       if (timerEnabled.current && !callbacksDisabled) {
-        const session = await getSession();
         const data = getSeatsReservationData(registrationId);
         const newTimeLeft = getRegistrationTimeLeft(data);
 
@@ -205,6 +205,7 @@ const ReservationTimer: React.FC<ReservationTimerProps> = ({
     callbacksDisabled,
     disableCallbacks,
     registrationId,
+    session,
     setOpenModal,
     setTimeLeft,
     timeLeft,

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -1,3 +1,4 @@
+import mapValues from 'lodash/mapValues';
 import { NextApiRequest, NextApiResponse } from 'next';
 import NextAuth, {
   Account,
@@ -146,7 +147,7 @@ export const jwtCallback = async (params: {
 
   if (refreshedToken?.error) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return undefined as any;
+    return null as any;
   }
 
   return refreshedToken;
@@ -163,7 +164,12 @@ export const sessionCallback = (params: {
 
   const { user, apiTokens, idToken } = token;
 
-  return { ...session, apiTokens, idToken, user };
+  return {
+    ...session,
+    apiTokens,
+    idToken,
+    user: mapValues(user, (value) => value ?? null) as OidcUser,
+  };
 };
 
 export const redirectCallback = async ({


### PR DESCRIPTION
## Description
Having undefined values in user data causes server errors when trying to serialise it. Fix the issue by replacing undefined values with null.
getSession function was executed every second in ReservationTimer component. Fix this by removing getSession function call from useEffect 
