### PR TITLE
LINK-2104 | Prevent to delete signup after event start_time

### DIFF
--- a/public/locales/en/signup.json
+++ b/public/locales/en/signup.json
@@ -124,6 +124,10 @@
     "capacityInWaitingList_other": "Registration for this event is still possible, but there are only {{count}} seats left in the queue.",
     "capacityInWaitingListNoLimit": "Registration for this event is still possible, but there are only seats left in the queue.",
     "closed": "Registration for this event is currently closed. Please try again later.",
-    "closedWithEnrolmentTime": "Registration for this event opens on {{openingDate}} at {{openingTime}}."
+    "closedWithEnrolmentTime": "Registration for this event opens on {{openingDate}} at {{openingTime}}.",
+    "eventStarted": "The event has already started and registration cannot be cancelled.",
+    "hasPaymentCancellation": "The payment is being cancelled and cannot be modified.",
+    "hasPaymentRefund": "The payment is being refunded and cannot be modified.",
+    "insufficientPermissions": "You do not have the right to edit registration details."
   }
 }

--- a/public/locales/fi/signup.json
+++ b/public/locales/fi/signup.json
@@ -123,6 +123,10 @@
     "capacityInWaitingList_other": "Ilmoittautuminen tähän tapahtumaan on vielä mahdollista, mutta jonopaikkoja on jäljellä vain {{count}} kpl.",
     "capacityInWaitingListNoLimit": "Ilmoittautuminen tähän tapahtumaan on vielä mahdollista, mutta vain jonopaikkoja on jäljellä.",
     "closed": "Ilmoittautuminen tähän tapahtumaan on tällä hetkellä suljettu. Kokeile myöhemmin uudelleen.",
-    "closedWithEnrolmentTime": "Ilmoittautuminen tähän tapahtumaan avautuu {{openingDate}} klo {{openingTime}}."
+    "closedWithEnrolmentTime": "Ilmoittautuminen tähän tapahtumaan avautuu {{openingDate}} klo {{openingTime}}.",
+    "eventStarted": "Tapahtuman on jo alkanut eikä ilmoittautumista voi perua.",
+    "hasPaymentCancellation": "Ilmoittautumisen maksua perutaan eikä sitä voi muokata.",
+    "hasPaymentRefund": "Ilmoittautumisen maksua hyvitetään eikä sitä voi muokata.",
+    "insufficientPermissions": "Sinulla ei ole oikeuksia muokata ilmoittautumisen tietoja."
   }
 }

--- a/public/locales/sv/signup.json
+++ b/public/locales/sv/signup.json
@@ -123,6 +123,10 @@
     "capacityInWaitingList_other": "Registrering för detta evenemang är fortfarande möjligt, men det är bara {{count}} platser kvar i kön.",
     "capacityInWaitingListNoLimit": "Registrering till detta evenemang är fortfarande möjlig, men det finns endast platser kvar i kön.",
     "closed": "Registreringen för detta evenemang är för närvarande stängd. Vänligen försök igen senare.",
-    "closedWithEnrolmentTime": "Anmälan till detta evenemang öppnar den {{openingDate}} kl {{openingTime}}."
+    "closedWithEnrolmentTime": "Anmälan till detta evenemang öppnar den {{openingDate}} kl {{openingTime}}.",
+    "eventStarted": "Evenemanget har redan börjat och registreringen kan inte avbrytas.",
+    "hasPaymentCancellation": "Anmälningsavgiften annulleras och kan inte ändras.",
+    "hasPaymentRefund": "Anmälningsavgiften återbetalas och kan inte ändras.",
+    "insufficientPermissions": "Du har inte rätt att ändra dina registreringsuppgifter."
   }
 }

--- a/src/domain/event/__mocks__/event.ts
+++ b/src/domain/event/__mocks__/event.ts
@@ -29,7 +29,7 @@ export const eventOverrides = {
   offers: fakeOffers(1, [
     { is_free: false, price: fakeLocalisedObject('Event price') },
   ]),
-  start_time: new Date().toISOString(),
+  start_time: addDays(new Date(), 1).toISOString(),
 };
 
 export const locationText = [locationName, streetAddress, addressLocality].join(

--- a/src/domain/event/__tests__/utils.test.ts
+++ b/src/domain/event/__tests__/utils.test.ts
@@ -24,6 +24,7 @@ import {
   getEventAttributes,
   getEventFields,
   getEventLocationText,
+  isEventStarted,
 } from '../utils';
 
 afterEach(() => {
@@ -344,4 +345,22 @@ describe('downloadEventIcsFile', () => {
       type: 'error',
     });
   });
+});
+
+describe('isEventStarted', () => {
+  it.each([
+    [fakeEvent({ start_time: null }), false],
+    [fakeEvent({ start_time: '2023-05-01' }), true],
+    [fakeEvent({ start_time: '2024-04-01' }), true],
+    [fakeEvent({ start_time: '2024-04-30' }), true],
+    [fakeEvent({ start_time: '2025-05-01' }), false],
+    [fakeEvent({ start_time: '2024-06-01' }), false],
+    [fakeEvent({ start_time: '2024-05-02' }), false],
+  ])(
+    'should return true if event is not started',
+    async (event, expectedResult) => {
+      advanceTo('2024-05-01');
+      expect(isEventStarted(event)).toBe(expectedResult);
+    }
+  );
 });

--- a/src/domain/event/utils.ts
+++ b/src/domain/event/utils.ts
@@ -1,4 +1,5 @@
 import { AxiosError } from 'axios';
+import isPast from 'date-fns/isPast';
 import { DateArray, DateTime, EventAttributes, createEvents } from 'ics';
 import { TFunction } from 'next-i18next';
 
@@ -186,4 +187,9 @@ export const eventPathBuilder = ({
   const query = queryBuilder(variableToKeyItems);
 
   return `/event/${id}/${query}`;
+};
+
+export const isEventStarted = (event: Event): boolean => {
+  const startTime = event.start_time ? new Date(event.start_time) : null;
+  return startTime ? isPast(startTime) : false;
 };

--- a/src/domain/registration/__mocks__/registration.ts
+++ b/src/domain/registration/__mocks__/registration.ts
@@ -2,6 +2,7 @@ import addDays from 'date-fns/addDays';
 import subDays from 'date-fns/subDays';
 
 import {
+  fakeEvent,
   fakeRegistration,
   fakeRegistrationPriceGroup,
 } from '../../../utils/mockDataUtils';
@@ -65,5 +66,15 @@ const registrationWithPriceGroup = fakeRegistration({
     }),
   ],
 });
+const registrationWithOnGoingEvent = fakeRegistration({
+  event: fakeEvent({
+    start_time: subDays(new Date(), 1).toISOString(),
+  }),
+});
 
-export { registration, registrationWithPriceGroup, registrationOverrides };
+export {
+  registration,
+  registrationWithOnGoingEvent,
+  registrationWithPriceGroup,
+  registrationOverrides,
+};

--- a/src/domain/signupGroup/editButtonPanel/EditButtonPanel.tsx
+++ b/src/domain/signupGroup/editButtonPanel/EditButtonPanel.tsx
@@ -8,8 +8,11 @@ import { SIGNUPS_SEARCH_PARAMS } from '../../singups/constants';
 import { SIGNUP_GROUP_ACTIONS } from '../constants';
 
 type EditButtonPanelProps = {
+  allowToCancel: boolean;
   allowToEdit: boolean;
+  cancelWarning: string;
   disabled: boolean;
+  editWarning: string;
   onCancel: () => void;
   onUpdate: () => void;
   savingSignup: SIGNUP_ACTIONS | null;
@@ -17,7 +20,10 @@ type EditButtonPanelProps = {
 };
 
 const EditButtonPanel: React.FC<EditButtonPanelProps> = ({
+  allowToCancel,
   allowToEdit,
+  cancelWarning,
+  editWarning,
   disabled,
   onCancel,
   onUpdate,
@@ -50,38 +56,38 @@ const EditButtonPanel: React.FC<EditButtonPanelProps> = ({
       onBack={
         router.query[SIGNUPS_SEARCH_PARAMS.RETURN_PATH] ? handleBack : undefined
       }
-      submitButtons={
-        allowToEdit
-          ? [
-              <Button
-                key="cancel"
-                iconLeft={<IconCross aria-hidden={true} />}
-                onClick={onCancel}
-                variant="danger"
-              >
-                {t('buttonCancel')}
-              </Button>,
-              <Button
-                key="update"
-                disabled={Boolean(
-                  disabled ||
-                    savingSignup === SIGNUP_ACTIONS.UPDATE ||
-                    savingSignupGroup === SIGNUP_GROUP_ACTIONS.UPDATE
-                )}
-                iconLeft={<IconPen aria-hidden={true} />}
-                isLoading={
-                  savingSignup === SIGNUP_ACTIONS.UPDATE ||
-                  savingSignupGroup === SIGNUP_GROUP_ACTIONS.UPDATE
-                }
-                loadingText={t('buttonUpdate')}
-                onClick={onUpdate}
-                variant="primary"
-              >
-                {t('buttonUpdate')}
-              </Button>,
-            ]
-          : []
-      }
+      submitButtons={[
+        <Button
+          key="cancel"
+          disabled={!allowToCancel}
+          iconLeft={<IconCross aria-hidden={true} />}
+          onClick={onCancel}
+          title={cancelWarning}
+          variant="danger"
+        >
+          {t('buttonCancel')}
+        </Button>,
+        <Button
+          key="update"
+          disabled={Boolean(
+            disabled ||
+              !allowToEdit ||
+              savingSignup === SIGNUP_ACTIONS.UPDATE ||
+              savingSignupGroup === SIGNUP_GROUP_ACTIONS.UPDATE
+          )}
+          iconLeft={<IconPen aria-hidden={true} />}
+          isLoading={
+            savingSignup === SIGNUP_ACTIONS.UPDATE ||
+            savingSignupGroup === SIGNUP_GROUP_ACTIONS.UPDATE
+          }
+          loadingText={t('buttonUpdate')}
+          onClick={onUpdate}
+          title={editWarning}
+          variant="primary"
+        >
+          {t('buttonUpdate')}
+        </Button>,
+      ]}
     ></ButtonPanel>
   );
 };


### PR DESCRIPTION
## Description
Prevent to delete a signup or a signup group after an event has started.

## Closes
[LINK-2104](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2104)



[LINK-2104]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ