### PR TITLE
fix: sentry add extra error data integration LINK-2186

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -2,6 +2,7 @@
 // The config you add here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
+import { extraErrorDataIntegration } from '@sentry/integrations';
 import * as Sentry from '@sentry/nextjs';
 
 import {
@@ -13,6 +14,8 @@ if (process.env.NODE_ENV === 'production') {
   Sentry.init({
     beforeSend,
     beforeSendTransaction,
+    normalizeDepth: 3,
+    integrations: [extraErrorDataIntegration({ depth: 3 })],
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
     environment: process.env.NEXT_PUBLIC_ENVIRONMENT,
     ignoreErrors: [

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -2,7 +2,7 @@
 // The config you add here will be used whenever one of the edge features is loaded.
 // Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
-
+import { extraErrorDataIntegration } from '@sentry/integrations';
 import * as Sentry from '@sentry/nextjs';
 
 import {
@@ -14,6 +14,8 @@ if (process.env.NODE_ENV === 'production') {
   Sentry.init({
     beforeSend,
     beforeSendTransaction,
+    normalizeDepth: 3,
+    integrations: [extraErrorDataIntegration({ depth: 3 })],
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
     environment: process.env.NEXT_PUBLIC_ENVIRONMENT,
 

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,7 +1,7 @@
 // This file configures the initialization of Sentry on the server.
 // The config you add here will be used whenever the server handles a request.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
-
+import { extraErrorDataIntegration } from '@sentry/integrations';
 import * as Sentry from '@sentry/nextjs';
 
 import {
@@ -13,6 +13,8 @@ if (process.env.NODE_ENV === 'production') {
   Sentry.init({
     beforeSend,
     beforeSendTransaction,
+    normalizeDepth: 3,
+    integrations: [extraErrorDataIntegration({ depth: 3 })],
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
     environment: process.env.NEXT_PUBLIC_ENVIRONMENT,
 

--- a/src/domain/app/sentry/utils.ts
+++ b/src/domain/app/sentry/utils.ts
@@ -68,12 +68,7 @@ const SENTRY_DENYLIST = [
   'zipcode',
 ];
 
-const MAX_CLEAN_DEPTH = 3;
-
-export const cleanSensitiveData = (data: Record<string, unknown>, depth: number = 0) => {
-  if (depth > MAX_CLEAN_DEPTH) {
-    return {};
-  };
+export const cleanSensitiveData = (data: Record<string, unknown>) => {
   Object.entries(data).forEach(([key, value]) => {
     if (
       SENTRY_DENYLIST.includes(key) ||
@@ -83,11 +78,11 @@ export const cleanSensitiveData = (data: Record<string, unknown>, depth: number 
     } else if (Array.isArray(value)) {
       data[key] = value.map((item) =>
         isObject(item)
-          ? cleanSensitiveData(item as Record<string, unknown>, depth + 1)
+          ? cleanSensitiveData(item as Record<string, unknown>)
           : item
       );
     } else if (isObject(value)) {
-      data[key] = cleanSensitiveData(value as Record<string, unknown>, depth + 1);
+      data[key] = cleanSensitiveData(value as Record<string, unknown>);
     }
   });
 


### PR DESCRIPTION
## Description :sparkles:
cleanSensitiveData depth check causes unwanted behaviour in signup. Replacing with [ExtraErrorData integration](https://docs.sentry.io/platforms/javascript/configuration/integrations/extraerrordata/) with depth set to 3.

## Issues :bug:

### Closes :no_good_woman:

**[LINK-2186](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2186):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[LINK-2186]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ