### PR TITLE
fix: a11y signup language aria-label LINK-2154

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -16,6 +16,7 @@
     }
   },
   "clear": "Clear",
+  "clearAllSelections": "Clear all selections",
   "close": "Close",
   "cookieConsent": {
     "expiration": {

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -16,6 +16,7 @@
     }
   },
   "clear": "Tyhjennä",
+  "clearAllSelections": "Tyhjennä kaikki valinnat",
   "close": "Sulje",
   "cookieConsent": {
     "expiration": {

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -16,6 +16,7 @@
     }
   },
   "clear": "Klar",
+  "clearAllSelections": "Ta bort alla val",
   "close": "Stäng",
   "cookieConsent": {
     "expiration": {

--- a/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
+++ b/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
@@ -542,6 +542,7 @@ const SignupGroupForm: React.FC<Props> = ({
                             t(`contactPerson.placeholderNativeLanguage`)
                           )}
                           title={titleCannotEditContactPerson}
+                          clearButtonAriaLabel={t('common:clearAllSelections')}
                         />
                         <Field
                           component={SingleSelectField}


### PR DESCRIPTION
## Description :sparkles:
Add missing clear button aria-label to signup language select.
## Issues :bug:

### Closes :no_good_woman:

**[LINK-2154](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2154):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[LINK-2154]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ