### PR TITLE
fix: a11y make buttonPanel non sticky LINK-2148

### DIFF
--- a/src/common/components/buttonPanel/buttonPanel.module.scss
+++ b/src/common/components/buttonPanel/buttonPanel.module.scss
@@ -3,14 +3,9 @@
 @import '../../../styles/widths';
 
 .buttonPanel {
-  position: sticky;
-  bottom: 0;
-  left: 0;
-  right: 0;
   padding: var(--spacing-m) 0;
   background-color: var(--color-white);
   border-top: 1px solid var(--color-black-10);
-  z-index: 9;
 }
 
 .formContainer {


### PR DESCRIPTION
## Description :sparkles:
Make buttonPanel non sticky so that SR focus cannot get hidden behind it.

## Issues :bug:

### Closes :no_good_woman:

**[LINK-2148](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2148):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[LINK-2148]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ