### PR TITLE
fix: a11y heading levels LINK-2150 LINK-2157

### DIFF
--- a/src/domain/signupGroup/instructions/Instructions.tsx
+++ b/src/domain/signupGroup/instructions/Instructions.tsx
@@ -5,6 +5,8 @@ import useLocale from '../../../hooks/useLocale';
 import { Registration } from '../../registration/types';
 import { getRegistrationFields } from '../../registration/utils';
 
+import styles from './instructions.module.scss';
+
 type Props = {
   registration: Registration;
 };
@@ -21,7 +23,7 @@ const Instructions: React.FC<Props> = ({ registration }) => {
 
   return (
     <>
-      <strong>{t('signup:instructions')}</strong>
+      <h2 className={styles.heading}>{t('signup:instructions')}</h2>
       {instructionsParts.map((part) => (
         <p key={part}>{part}</p>
       ))}

--- a/src/domain/signupGroup/instructions/instructions.module.scss
+++ b/src/domain/signupGroup/instructions/instructions.module.scss
@@ -1,0 +1,4 @@
+h2.heading {
+  font-size: var(--fontsize-heading-xxs);
+  margin: 0;
+}

--- a/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
+++ b/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
@@ -486,24 +486,25 @@ const SignupGroupForm: React.FC<Props> = ({
                     </FormGroup>
                   </Fieldset>
 
-                  <Fieldset heading={t(`contactPerson.titleNotifications`)}>
-                    <FormGroup>
-                      <Field
-                        name={getContactPersonFieldName(
-                          CONTACT_PERSON_FIELDS.NOTIFICATIONS
-                        )}
-                        className={styles.notifications}
-                        component={CheckboxGroupField}
-                        disabled={true}
-                        label={getPlaceholder(
-                          t(`contactPerson.titleNotifications`)
-                        )}
-                        options={notificationOptions}
-                        required
-                        title={titleCannotEditContactPerson}
-                      />
-                    </FormGroup>
-                  </Fieldset>
+                  <FormGroup>
+                    <h3 className={styles.formGroupTitle}>
+                      {t(`contactPerson.titleNotifications`)}
+                    </h3>
+                    <Field
+                      name={getContactPersonFieldName(
+                        CONTACT_PERSON_FIELDS.NOTIFICATIONS
+                      )}
+                      className={styles.notifications}
+                      component={CheckboxGroupField}
+                      disabled={true}
+                      label={getPlaceholder(
+                        t(`contactPerson.titleNotifications`)
+                      )}
+                      options={notificationOptions}
+                      required
+                      title={titleCannotEditContactPerson}
+                    />
+                  </FormGroup>
 
                   <Fieldset heading={t(`contactPerson.titleAdditionalInfo`)}>
                     <FormGroup>

--- a/src/domain/signupGroup/signupGroupForm/signupGroupForm.module.scss
+++ b/src/domain/signupGroup/signupGroupForm/signupGroupForm.module.scss
@@ -18,6 +18,11 @@
   margin-bottom: calc(0px - var(--spacing-xs));
 }
 
+.formGroupTitle {
+  font-size: var(--fontsize-body-l);
+  margin-bottom: var(--spacing-s);
+}
+
 .notifications {
   margin-top: var(--spacing-m);
 }

--- a/src/domain/signupGroup/signupGroupForm/signups/signup/Signup.tsx
+++ b/src/domain/signupGroup/signupGroupForm/signups/signup/Signup.tsx
@@ -1,9 +1,10 @@
 import { Field } from 'formik';
-import { Fieldset, IconTrash } from 'hds-react';
+import { IconTrash } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import React, { useMemo } from 'react';
 
 import Accordion from '../../../../../common/components/accordion/Accordion';
+import Fieldset from '../../../../../common/components/fieldset/Fieldset';
 import DateInputField from '../../../../../common/components/formFields/DateInputField';
 import SingleSelectField from '../../../../../common/components/formFields/SingleSelectField';
 import TextAreaField from '../../../../../common/components/formFields/TextAreaField';

--- a/src/domain/signupGroup/summaryPage/contactPersonInfo/ContactPersonInfo.tsx
+++ b/src/domain/signupGroup/summaryPage/contactPersonInfo/ContactPersonInfo.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from 'next-i18next';
 import React, { FC } from 'react';
 
-import Fieldset from '../../../../common/components/fieldset/Fieldset';
 import FormGroup from '../../../../common/components/formGroup/FormGroup';
 import TextArea from '../../../../common/components/textArea/TextArea';
 import skipFalsyType from '../../../../utils/skipFalsyType';
@@ -40,7 +39,9 @@ const ContactPersonInfo: FC<Props> = ({
     <div>
       <h2>{t('contactPerson.titleContactPersonInfo')}</h2>
       <Divider />
-      <Fieldset heading={t(`contactPerson.titleContactInfo`)}>
+
+      <FormGroup>
+        <h3>{t(`contactPerson.titleContactInfo`)}</h3>
         <FormGroup>
           <div className={styles.emailRow}>
             <ReadOnlyTextInput
@@ -69,21 +70,21 @@ const ContactPersonInfo: FC<Props> = ({
             />
           </div>
         </FormGroup>
-      </Fieldset>
+      </FormGroup>
 
-      <Fieldset heading={t(`contactPerson.titleNotifications`)}>
-        <FormGroup>
-          <ReadOnlyTextInput
-            id={CONTACT_PERSON_FIELDS.NOTIFICATIONS}
-            label={t(`contactPerson.labelNotifications`)}
-            value={getFieldText(
-              getNotificationsText(contactPerson.notifications)
-            )}
-          />
-        </FormGroup>
-      </Fieldset>
+      <FormGroup>
+        <h3>{t(`contactPerson.titleNotifications`)}</h3>
+        <ReadOnlyTextInput
+          id={CONTACT_PERSON_FIELDS.NOTIFICATIONS}
+          label={t(`contactPerson.labelNotifications`)}
+          value={getFieldText(
+            getNotificationsText(contactPerson.notifications)
+          )}
+        />
+      </FormGroup>
 
-      <Fieldset heading={t(`contactPerson.titleAdditionalInfo`)}>
+      <FormGroup>
+        <h3>{t(`contactPerson.titleAdditionalInfo`)}</h3>
         <FormGroup>
           <div className={styles.membershipNumberRow}>
             <ReadOnlyTextInput
@@ -118,7 +119,7 @@ const ContactPersonInfo: FC<Props> = ({
           readOnly
           value={getFieldText(extraInfo)}
         />
-      </Fieldset>
+      </FormGroup>
     </div>
   );
 };


### PR DESCRIPTION
## Description :sparkles:

Fixing signup form heading levels.

## Issues :bug:

### Closes :no_good_woman:

**[LINK-2150](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2150)**
**[LINK-2157](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2157)**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[LINK-2150]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LINK-2157]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ