### PR TITLE
fix: error handling enhancements LINK-2158

### DIFF
--- a/src/domain/signup/signupServerErrorsContext/__tests__/utils.test.ts
+++ b/src/domain/signup/signupServerErrorsContext/__tests__/utils.test.ts
@@ -18,7 +18,7 @@ describe('parseSignupGroupServerErrors', () => {
         {
           city: ['Tämän kentän arvo ei voi olla "null".'],
           detail: 'The participant is too old.',
-          firstName: ['The name must be specified.'],
+          first_name: ['The name must be specified.'],
           non_field_errors: [
             'Kenttien email, registration tulee muodostaa uniikki joukko.',
             'Kenttien phone_number, registration tulee muodostaa uniikki joukko.',
@@ -56,8 +56,8 @@ describe('parseSignupGroupServerErrors', () => {
 
   it('should return server error items when result is array', () => {
     const error = [
-      { firstName: ['The name must be specified.'] },
-      { lastName: ['The name must be specified.'] },
+      { first_name: ['The name must be specified.'] },
+      { last_name: ['The name must be specified.'] },
     ];
 
     expect(

--- a/src/domain/signup/signupServerErrorsContext/utils.ts
+++ b/src/domain/signup/signupServerErrorsContext/utils.ts
@@ -100,17 +100,22 @@ export const parseSignupGroupServerErrors = ({
   function parseSignupServerError(error: LEServerError): ServerErrorItem[] {
     /* istanbul ignore else */
     if (Array.isArray(error)) {
-      return Object.entries(error[0]).reduce(
-        (previous: ServerErrorItem[], [key, e]) => [
-          ...previous,
-          {
-            label: parseServerErrorLabel({
-              key,
-              parseFn: parseSignupGroupServerErrorLabel,
-            }),
-            message: parseServerErrorMessage({ error: e as string[], t }),
-          },
-        ],
+      return Object.entries(error).reduce(
+        (previous: ServerErrorItem[], [, e]) => {
+          return [
+            ...previous,
+            ...Object.entries(e).map(([key, item]) => ({
+              label: parseServerErrorLabel({
+                key,
+                parseFn: parseSignupGroupServerErrorLabel,
+              }),
+              message: parseServerErrorMessage({
+                error: item as string[],
+                t,
+              }),
+            })),
+          ];
+        },
         []
       );
     } else {
@@ -132,7 +137,23 @@ export const parseSignupGroupServerErrors = ({
       return t(`signup:label${pascalCase(key)}`);
     }
 
-    return t(`signup:signup.label${pascalCase(key)}`);
+    if (
+      [
+        'city',
+        'date_of_birth',
+        'extra_info',
+        'first_name',
+        'last_name',
+        'phone_number',
+        'price_group',
+        'zip_code',
+        'street_address',
+      ].includes(key)
+    ) {
+      return t(`signup:signup.label${pascalCase(key)}`);
+    }
+
+    return '';
   }
 };
 


### PR DESCRIPTION
## Description :sparkles:

## Issues :bug:

When adding multiple signups, only errors for the first one are currently displayed. Fixing so that errors for all persons are listed. Also making use of all the label translations available that can be then displayed in the error message.

### Closes :no_good_woman:

**[LINK-2158](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2158):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[LINK-2158]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ