### PR TITLE
fix: added screen capture suggestion after registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 jest-report.xml
 
 # next.js
+next-env.d.ts
 /.next/
 /out/
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/public/locales/en/signup.json
+++ b/public/locales/en/signup.json
@@ -10,6 +10,7 @@
   "completedPage": {
     "redirectInfo1": "You will be automatically redirected to the service provider's page.",
     "redirectInfo2": "If the redirect does not work, you can access the page <a href=\"{{url}}\">here</a>.",
+    "suggestScreencap": "Due to email forwarding problems, please take a screenshot of this page in case you do not receive a confirmation email.",
     "text": "You have signed up to our event {{name}} - welcome!",
     "textWaitingList": "You have signed up for the {{name}} reserve place. If a place becomes available for you, you will receive a separate confirmation message to your e-mail about your registration.",
     "title": "Thank you for signing up!"

--- a/public/locales/fi/signup.json
+++ b/public/locales/fi/signup.json
@@ -10,6 +10,7 @@
   "completedPage": {
     "redirectInfo1": "Sinut ohjataan automaattisesti palveluntarjoajan sivulle.",
     "redirectInfo2": "Jos uudelleenohjaus ei toimi, pääset sivulle <a href=\"{{url}}\">tästä</a>.",
+    "suggestScreencap": "Sähköpostien välitysongelmien vuoksi, otathan itsellesi kuvakaappauksen talteen tästä sivusta, jos et saakaan vahvistusviestiä sähköpostiin.",
     "text": "Olet ilmoittanut tapahtumaamme {{name}} – sydämellisesti tervetuloa!",
     "textWaitingList": "Olet ilmoittautunut tapahtuman {{name}} jonoon. Mikäli sinulle vapautuu paikka, saat ilmoittautumisestasi erillisen vahvistusviestin sähköpostiisi.",
     "title": "Kiitos ilmoittautumisestasi!"

--- a/public/locales/sv/signup.json
+++ b/public/locales/sv/signup.json
@@ -10,6 +10,7 @@
   "completedPage": {
     "redirectInfo1": "Du kommer automatiskt att omdirigeras till tjänsteleverantörens sida.",
     "redirectInfo2": "Om omdirigeringen inte fungerar kan du komma åt sidan <a href=\"{{url}}\">här</a>.",
+    "suggestScreencap": "På grund av problem med vidarebefordran av e-post ber vi dig ta en skärmdump av denna sida om du inte får ett bekräftelsemeddelande.",
     "text": "Du har registrerat dig för vårt evenemang {{name}} - välkommen!",
     "textWaitingList": "Du har registrerat dig för {{name}} reservplats. Om en plats blir ledig för dig får du ett separat bekräftelsemeddelande till din e-post om din anmälan.",
     "title": "Tack för din registrering!"

--- a/src/domain/signupGroup/SignupGroupCompletedPage.tsx
+++ b/src/domain/signupGroup/SignupGroupCompletedPage.tsx
@@ -60,6 +60,9 @@ export const SignupCompletedPage: React.FC<Props> = ({
             ? t('signup:completedPage.textWaitingList', { name })
             : t('signup:completedPage.text', { name })}
         </p>
+        <p>
+          {t('signup:completedPage.suggestScreencap')}
+        </p>
         {confirmationMessage && (
           <ConfirmationMessage registration={registration} />
         )}


### PR DESCRIPTION
## Description :sparkles:
Added suggestion to take a screencapture after registration to event.
## Issues :bug:

### Closes :no_good_woman:

**[LINK-2195](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2195):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[LINK-2195]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ