### PR TITLE
fix: sort attendees by id (from oldest to newest) instead of name

### DIFF
--- a/src/domain/attendanceList/attendeeList/AttendeeList.tsx
+++ b/src/domain/attendanceList/attendeeList/AttendeeList.tsx
@@ -34,7 +34,7 @@ const AttendeeList: React.FC<Props> = ({ registration }) => {
 
   const attendees = orderBy(
     registration.signups as Signup[],
-    ['first_name', 'last_name'],
+    ['id'],
     ['asc', 'asc']
   ).filter((signup) => signup.attendee_status === ATTENDEE_STATUS.Attending);
 


### PR DESCRIPTION
refs: LINK-2220


