### PR TITLE
feat: add cookies page LINK-2152

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -49,6 +49,15 @@
     "label": "Add to calendar",
     "failedToCreateFile": "Failed to create calendar file"
   },
+  "footer": {
+    "backToTopLabel": "Back to top",
+    "copyrightHolder": "City of Helsinki",
+    "copyrightText": "All rights reserved.",
+    "tabs": {
+      "accessibilityStatement": "Accessibility Statement",
+      "cookies": "Cookie settings"
+    }
+  },
   "frontPage": "Frontpage",
   "headerTitle": "City of Helsinki",
   "helsinkiProfile": "Helsinki profile",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -49,6 +49,15 @@
     "label": "Lisää kalenteriin",
     "failedToCreateFile": "Kalenteritiedoston luominen epäonnistui."
   },
+  "footer": {
+    "backToTopLabel": "Palaa ylös",
+    "copyrightHolder": "Helsingin kaupunki",
+    "copyrightText": "Kaikki oikeudet pidätetään.",
+    "tabs": {
+      "accessibilityStatement": "Saavutettavuusseloste",
+      "cookies": "Evästeasetukset"
+    }
+  },
   "frontPage": "Etusivu",
   "headerTitle": "Helsingin kaupunki",
   "helsinkiProfile": "Helsinki-profiili",
@@ -71,7 +80,6 @@
       "fi": "Suomeksi",
       "sv": "På svenska"
     },
-
     "menuToggleAriaLabel": "Valikko",
     "skipToContentLabel": "Siirry sisältöön"
   },

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -49,6 +49,15 @@
     "label": "Lägg till i kalendern",
     "failedToCreateFile": "Det gick inte att skapa kalenderfil"
   },
+  "footer": {
+    "backToTopLabel": "Tillbaka till toppen",
+    "copyrightHolder": "Helsingfors stad",
+    "copyrightText": "Alla rättigheter förbehållna.",
+    "tabs": {
+      "accessibilityStatement": "Tillgänglighetsutlåtande",
+      "cookies": "Cookie -inställningar"
+    }
+  },
   "frontPage": "Hemsida",
   "headerTitle": "Helsingfors Stad",
   "helsinkiProfile": "Helsingfors profil",

--- a/src/__tests__/Pages.test.tsx
+++ b/src/__tests__/Pages.test.tsx
@@ -28,6 +28,9 @@ import {
 import { SignupGroupFormFields } from '../domain/signupGroup/types';
 import { mockedUserResponse } from '../domain/user/__mocks__/user';
 import { TEST_USER_ID } from '../domain/user/constants';
+import CookiesPage, {
+  getServerSideProps as getCookiesPageServerSideProps,
+} from '../pages/cookies';
 import PaymentCancelledPage, {
   getServerSideProps as getPaymentCancelledPageServerSideProps,
 } from '../pages/failure';
@@ -504,6 +507,24 @@ describe('LogoutPage', () => {
     const { props } = (await getLogoutPageServerSideProps({
       locale: 'fi',
       query: { registrationId: registration.id },
+    } as unknown as GetServerSidePropsContext)) as {
+      props: ExtendedSSRConfig;
+    };
+
+    expect(props._nextI18Next?.ns).toEqual(['common']);
+  });
+});
+
+describe('Cookies', () => {
+  it('should render', () => {
+    singletonRouter.push({ pathname: ROUTES.COOKIES });
+
+    render(<CookiesPage />);
+  });
+
+  it('should get correct translations namespaces', async () => {
+    const { props } = (await getCookiesPageServerSideProps({
+      locale: 'fi',
     } as unknown as GetServerSidePropsContext)) as {
       props: ExtendedSSRConfig;
     };

--- a/src/domain/app/footer/Footer.tsx
+++ b/src/domain/app/footer/Footer.tsx
@@ -1,0 +1,49 @@
+import { Footer as HdsFooter, Logo, logoFi, LogoSize, logoSv } from 'hds-react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import useLocale from '../../../hooks/useLocale';
+import { Language } from '../../../types';
+
+import styles from './footer.module.scss';
+
+const logoSrcFromLanguage = (lang: Language) => {
+  if (lang === 'sv') {
+    return logoSv;
+  }
+  return logoFi;
+};
+
+const Footer: React.FC = () => {
+  const { t } = useTranslation('common');
+  const locale = useLocale();
+
+  return (
+    <HdsFooter className={styles.footer} korosType="calm" title={t('appName')}>
+      <HdsFooter.Base
+        copyrightHolder={t('footer.copyrightHolder')}
+        copyrightText={t('footer.copyrightText')}
+        backToTopLabel={t('footer.backToTopLabel')}
+        logo={
+          <Logo
+            src={logoSrcFromLanguage(locale)}
+            size={LogoSize.Medium}
+            alt={t('logo')}
+          />
+        }
+        logoHref="https://hel.fi"
+      >
+        <HdsFooter.Link
+          href={`https://linkedevents.hel.fi/${locale}/accessibility-statement`}
+          label={t('footer.tabs.accessibilityStatement')}
+        />
+        <HdsFooter.Link
+          href={`/${locale}/cookies`}
+          label={t('footer.tabs.cookies')}
+        />
+      </HdsFooter.Base>
+    </HdsFooter>
+  );
+};
+
+export default Footer;

--- a/src/domain/app/footer/footer.module.scss
+++ b/src/domain/app/footer/footer.module.scss
@@ -1,0 +1,3 @@
+.footer {
+  --container-width-xl: 1392px;
+}

--- a/src/domain/app/layout/pageLayout/PageLayout.tsx
+++ b/src/domain/app/layout/pageLayout/PageLayout.tsx
@@ -5,7 +5,9 @@ import { useRouter } from 'next/router';
 import React, { useEffect } from 'react';
 
 import { SIGNUP_QUERY_PARAMS } from '../../../signup/constants';
+import Footer from '../../footer/Footer';
 import Header from '../../header/Header';
+import { ROUTES } from '../../routes/constants';
 
 import styles from './pageLayout.module.scss';
 
@@ -20,8 +22,10 @@ const PageLayout: React.FC<React.PropsWithChildren<unknown>> = ({
 }) => {
   const {
     query: { [SIGNUP_QUERY_PARAMS.IFRAME]: iframe },
+    pathname,
   } = useRouter();
   const isIframe = iframe === 'true';
+  const isCookiesPage = pathname === ROUTES.COOKIES;
 
   const statisticsConsent = useGroupConsent('statistics');
 
@@ -45,10 +49,12 @@ const PageLayout: React.FC<React.PropsWithChildren<unknown>> = ({
     <div
       className={classNames(styles.pageLayout, {
         [styles.pageLayoutWithoutHeader]: isIframe,
+        [styles.pageLayoutWhiteBackground]: isCookiesPage,
       })}
     >
       {!isIframe && <Header />}
       <div className={styles.pageBody}>{children}</div>
+      {!isIframe && <Footer />}
     </div>
   );
 };

--- a/src/domain/app/layout/pageLayout/pageLayout.module.scss
+++ b/src/domain/app/layout/pageLayout/pageLayout.module.scss
@@ -12,7 +12,7 @@
 .pageBody {
   display: grid;
   background-color: var(--background-color-body);
-  padding: var(--padding-body);
+  padding: var(--spacing-l) var(--spacing-m) var(--spacing-5-xl);
 
   h1 {
     font-size: var(--fontsize-heading-l);
@@ -25,4 +25,8 @@
 
 .pageLayoutWithoutHeader {
   grid-template-rows: 1fr !important;
+}
+
+.pageLayoutWhiteBackground {
+  --background-color-body: var(--color-white);
 }

--- a/src/domain/app/routes/constants.ts
+++ b/src/domain/app/routes/constants.ts
@@ -1,6 +1,7 @@
 export enum ROUTES {
   ATTENDANCE_LIST = '/registration/[registrationId]/attendance-list',
   CALLBACK = '/api/auth/callback/tunnistamo',
+  COOKIES = '/cookies',
   CREATE_SIGNUP_GROUP = '/registration/[registrationId]/signup-group/create',
   CREATE_SIGNUP_GROUP_SUMMARY = '/registration/[registrationId]/signup-group/create/summary',
   EDIT_SIGNUP = '/registration/[registrationId]/signup/[signupId]/edit',

--- a/src/pages/cookies/index.tsx
+++ b/src/pages/cookies/index.tsx
@@ -1,12 +1,12 @@
 import { CookieSettingsPage } from 'hds-react';
-import { GetStaticProps } from 'next';
+import { GetServerSideProps } from 'next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import React from 'react';
 
-export const getStaticProps: GetStaticProps = async ({ locale }) => {
+export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
   return {
     props: {
-      ...(await serverSideTranslations(locale ?? 'fi', ['common'])),
+      ...(await serverSideTranslations(locale as string, ['common'])),
     },
   };
 };

--- a/src/pages/cookies/index.tsx
+++ b/src/pages/cookies/index.tsx
@@ -1,0 +1,18 @@
+import { CookieSettingsPage } from 'hds-react';
+import { GetStaticProps } from 'next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import React from 'react';
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale ?? 'fi', ['common'])),
+    },
+  };
+};
+
+const CookiesPage = (): React.ReactElement => {
+  return <CookieSettingsPage />;
+};
+
+export default CookiesPage;


### PR DESCRIPTION
## Description :sparkles:
Users should be able to change consent settings. Added simple footer and cookies page.
## Issues :bug:

### Closes :no_good_woman:

**[LINK-1759](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1759):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:
<img width="1239" alt="Screenshot 2025-04-15 at 12 03 14" src="https://github.com/user-attachments/assets/578531c5-0920-45b9-ae62-ddc8df4fe1ee" />
<br><br>
<img width="1237" alt="Screenshot 2025-04-15 at 12 07 13" src="https://github.com/user-attachments/assets/6f7b7f9c-0915-47d3-9062-4a186bef3c39" />

## Additional notes :spiral_notepad:


[LINK-1759]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ