### PR TITLE
fix: tell sonar to skip two lines KEH-191

### DIFF
--- a/src/domain/singups/__mocks__/testUtils.ts
+++ b/src/domain/singups/__mocks__/testUtils.ts
@@ -49,7 +49,12 @@ export const shouldExportSignupsAsExcel = async (
   // Mock document.createElement which is needed by downloadBlob. RenderComponent needs
   // createElement so do this after rendering components to avoid errors
   const createElement = document.createElement;
-  document.createElement = vi.fn().mockImplementation(() => link);
+  document.createElement = vi
+    .fn()
+    .mockImplementation((tagName: string, ...args: any[]) => {
+      if (tagName === 'a') return link;
+      return createElement.call(document, tagName, ...args);
+    });
 
   await user.click(exportAsExcelButton);
 

--- a/src/utils/testUtils.tsx
+++ b/src/utils/testUtils.tsx
@@ -143,11 +143,11 @@ const actWait = (amount?: number): Promise<void> => act(() => wait(amount));
 
 const mockNumberString = (size: number): string =>
   [...Array(size)]
-    .map(() => Math.floor(Math.random() * 10).toString())
+    .map(() => Math.floor(Math.random() * 10).toString()) // NOSONAR
     .join('');
 
 const mockString = (size: number): string =>
-  [...Array(size)].map(() => Math.random().toString(36)[2]).join('');
+  [...Array(size)].map(() => Math.random().toString(36)[2]).join(''); // NOSONAR
 
 const loadingSpinnerIsNotInDocument = async (timeout = 1000): Promise<void> =>
   waitFor(


### PR DESCRIPTION
Refs: KEH-191

## Description :sparkles:

Sonar complains about math random being used. But it is used only in unit tests.
Decided to skip sonar on those lines.

Edit.
Also fix a unit test that is failing for some reason.


### Closes :no_good_woman:

**[KEH-191](https://helsinkisolutionoffice.atlassian.net/browse/KEH-191):**



[KEH-191]: https://helsinkisolutionoffice.atlassian.net/browse/KEH-191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ